### PR TITLE
Include sys/param.h for MIN definition

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/queue.h>
+#include <sys/param.h>
 #include <assert.h>
 #include <uv.h>
 #include <libdrm/drm_fourcc.h>


### PR DESCRIPTION
Fixes #11.