### PR TITLE
External event loop

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -76,6 +76,12 @@ struct nvnc_client {
 	uint8_t msg_buffer[MSG_BUFFER_SIZE];
 };
 
+struct nvnc_poll {
+	struct nvnc_common common;
+	nvnc_poll_callback_fn poll_callback_fn;
+	void *priv;
+};
+
 LIST_HEAD(nvnc_client_list, nvnc_client);
 
 struct vnc_display {
@@ -88,10 +94,12 @@ struct vnc_display {
 struct nvnc {
 	struct nvnc_common common;
 	int fd;
-	uv_poll_t poll_handle;
+	struct nvnc_poll poll;
 	struct nvnc_client_list clients;
 	struct vnc_display display;
 	void* userdata;
+	nvnc_poll_start_fn poll_start_fn;
+	nvnc_poll_stop_fn poll_stop_fn;
 	nvnc_key_fn key_fn;
 	nvnc_pointer_fn pointer_fn;
 	nvnc_fb_req_fn fb_req_fn;

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -44,7 +44,8 @@ typedef void (*nvnc_damage_fn)(struct pixman_region16* damage, void* userdata);
 typedef bool (*nvnc_auth_fn)(const char* username, const char* password,
                              void* userdata);
 
-struct nvnc* nvnc_open(const char* addr, uint16_t port);
+struct nvnc* nvnc_create(void);
+int nvnc_open(struct nvnc*, const char* addr, uint16_t port);
 void nvnc_close(struct nvnc* self);
 
 void nvnc_set_userdata(void* self, void* userdata);

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -22,6 +22,7 @@
 struct nvnc;
 struct nvnc_client;
 struct nvnc_fb;
+struct nvnc_poll;
 struct pixman_region16;
 
 enum nvnc_button_mask {
@@ -30,6 +31,13 @@ enum nvnc_button_mask {
 	NVNC_BUTTON_RIGHT = 1 << 2,
 	NVNC_SCROLL_UP = 1 << 3,
 	NVNC_SCROLL_DOWN = 1 << 4,
+};
+
+enum {
+	NVNC_EVENT_READABLE = 0x01,
+	NVNC_EVENT_WRITABLE = 0x02,
+	NVNC_EVENT_HANGUP   = 0x04,
+	NVNC_EVENT_ERROR    = 0x08
 };
 
 typedef void (*nvnc_key_fn)(struct nvnc_client*, uint32_t keysym,
@@ -43,6 +51,12 @@ typedef void (*nvnc_client_fn)(struct nvnc_client*);
 typedef void (*nvnc_damage_fn)(struct pixman_region16* damage, void* userdata);
 typedef bool (*nvnc_auth_fn)(const char* username, const char* password,
                              void* userdata);
+typedef void (*nvnc_poll_callback_fn)(struct nvnc_poll *poll, uint32_t mask);
+typedef void (*nvnc_poll_start_fn)(struct nvnc* self, struct nvnc_poll *poll,
+				   int fd, uint32_t mask);
+typedef void (*nvnc_poll_stop_fn)(struct nvnc* self, struct nvnc_poll *poll);
+
+nvnc_poll_callback_fn nvnc_poll_get_cb(const struct nvnc_poll* poll);
 
 struct nvnc* nvnc_create(void);
 int nvnc_open(struct nvnc*, const char* addr, uint16_t port);
@@ -58,6 +72,8 @@ void nvnc_set_dimensions(struct nvnc* self, uint16_t width, uint16_t height,
 
 void nvnc_set_name(struct nvnc* self, const char* name);
 
+void nvnc_set_poll_start_fn(struct nvnc* self, nvnc_poll_start_fn);
+void nvnc_set_poll_stop_fn(struct nvnc* self, nvnc_poll_stop_fn);
 void nvnc_set_key_fn(struct nvnc* self, nvnc_key_fn);
 void nvnc_set_pointer_fn(struct nvnc* self, nvnc_pointer_fn);
 void nvnc_set_fb_req_fn(struct nvnc* self, nvnc_fb_req_fn);

--- a/include/stream.h
+++ b/include/stream.h
@@ -14,11 +14,10 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <uv.h>
-
 #include "config.h"
 #include "sys/queue.h"
 #include "rcbuf.h"
+#include "common.h"
 
 #ifdef ENABLE_TLS
 #include <gnutls/gnutls.h>
@@ -66,7 +65,8 @@ struct stream {
 	enum stream_state state;
 
 	int fd;
-	uv_poll_t uv_poll;
+	struct nvnc* server;
+	struct nvnc_poll poll;
 	stream_event_fn on_event;
 	void* userdata;
 
@@ -77,7 +77,8 @@ struct stream {
 #endif
 };
 
-struct stream* stream_new(int fd, stream_event_fn on_event, void* userdata);
+struct stream* stream_new(int fd, stream_event_fn on_event, void* userdata,
+			  struct nvnc* server);
 int stream_close(struct stream* self);
 void stream_destroy(struct stream* self);
 ssize_t stream_read(struct stream* self, void* dst, size_t size);

--- a/src/damage.c
+++ b/src/damage.c
@@ -130,6 +130,7 @@ int check_damage_linear_threaded(struct nvnc_fb* fb0, struct nvnc_fb* fb1,
 	pixman_region_init(&work->damage);
 
 	/* TODO: Spread the work into more tasks */
+	fprintf(stderr, "check_damage_linear_threaded, call uv_queue_work\n");
 	int rc = uv_queue_work(uv_default_loop(), &work->work,
 	                       do_damage_check_linear,
 	                       on_damage_check_done_linear);

--- a/src/server.c
+++ b/src/server.c
@@ -747,11 +747,16 @@ accept_failure:
 }
 
 EXPORT
-struct nvnc* nvnc_open(const char* address, uint16_t port)
+struct nvnc* nvnc_create(void)
 {
-	struct nvnc* self = calloc(1, sizeof(*self));
+	return calloc(1, sizeof(struct nvnc));
+}
+
+EXPORT
+int nvnc_open(struct nvnc* self, const char* address, uint16_t port)
+{
 	if (!self)
-		return NULL;
+		return -1;
 
 	strcpy(self->display.name, DEFAULT_NAME);
 
@@ -759,7 +764,7 @@ struct nvnc* nvnc_open(const char* address, uint16_t port)
 
 	self->fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (self->fd < 0)
-		return NULL;
+		return -1;
 
 	int one = 1;
 	if (setsockopt(self->fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(int)) < 0)
@@ -779,11 +784,11 @@ struct nvnc* nvnc_open(const char* address, uint16_t port)
 	uv_poll_init(uv_default_loop(), &self->poll_handle, self->fd);
 	uv_poll_start(&self->poll_handle, UV_READABLE, on_connection);
 
-	return self;
+	return 0;
 
 failure:
 	close(self->fd);
-	return NULL;
+	return -1;
 }
 
 EXPORT


### PR DESCRIPTION
Hi,

This implements support for external event loop as discussed in #16. It is somewhat rough and obviously breaks API, but seems to work with an adopted Weston VNC backend:
https://gitlab.freedesktop.org/agners/weston/-/commits/rfc-vnc-support-with-neatvnc-wayland-event-loop