### PR TITLE
Use static for functions not used outside this compile unit

### DIFF
--- a/include/fb.h
+++ b/include/fb.h
@@ -25,7 +25,6 @@
 struct nvnc_fb {
 	int ref;
 	void* addr;
-	atomic_bool is_locked;
 	enum nvnc_fb_flags flags;
 	size_t size;
 	uint16_t width;

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ host_system = host_machine.system()
 c_args = [
 	'-D_GNU_SOURCE',
 	'-fvisibility=hidden',
+	'-Wmissing-prototypes',
 ]
 
 if buildtype != 'debug' and buildtype != 'debugoptimized'

--- a/src/damage.c
+++ b/src/damage.c
@@ -61,9 +61,11 @@ static inline bool are_tiles_equal(const uint32_t* a, const uint32_t* b,
 }
 
 #define TILE_SIDE_LENGTH 32
-int check_damage_linear(struct pixman_region16* damage,
-                        const struct nvnc_fb* fb0, const struct nvnc_fb* fb1,
-                        int x_hint, int y_hint, int width_hint, int height_hint)
+static int check_damage_linear(struct pixman_region16* damage,
+                               const struct nvnc_fb* fb0,
+                               const struct nvnc_fb* fb1,
+                               int x_hint, int y_hint,
+                               int width_hint, int height_hint)
 {
 	uint32_t* b0 = fb0->addr;
 	uint32_t* b1 = fb1->addr;
@@ -102,7 +104,7 @@ int check_damage_linear(struct pixman_region16* damage,
 }
 #undef TILE_SIDE_LENGTH
 
-void do_damage_check_linear(void* work)
+static void do_damage_check_linear(void* work)
 {
 	struct damage_check* check = aml_get_userdata(work);
 
@@ -111,7 +113,7 @@ void do_damage_check_linear(void* work)
 	                    check->height_hint);
 }
 
-void on_damage_check_done_linear(void* work)
+static void on_damage_check_done_linear(void* work)
 {
 	struct damage_check* check = aml_get_userdata(work);
 
@@ -123,10 +125,12 @@ void on_damage_check_done_linear(void* work)
 	pixman_region_fini(&check->damage);
 }
 
-int check_damage_linear_threaded(struct nvnc_fb* fb0, struct nvnc_fb* fb1,
-                                 int x_hint, int y_hint,
-                                 int width_hint, int height_hint,
-                                 nvnc_damage_fn on_check_done, void* userdata)
+static int check_damage_linear_threaded(struct nvnc_fb* fb0,
+                                        struct nvnc_fb* fb1,
+                                        int x_hint, int y_hint,
+                                        int width_hint, int height_hint,
+                                        nvnc_damage_fn on_check_done,
+                                        void* userdata)
 {
 	struct damage_check* work = calloc(1, sizeof(*work));
 	if (!work)

--- a/src/display.c
+++ b/src/display.c
@@ -37,7 +37,7 @@ struct nvnc_display* nvnc_display_new(uint16_t x_pos, uint16_t y_pos)
 	return self;
 }
 
-void nvnc__display_free(struct nvnc_display* self)
+static void nvnc__display_free(struct nvnc_display* self)
 {
 	if (self->buffer)
 		nvnc_fb_unref(self->buffer);

--- a/src/fb.c
+++ b/src/fb.c
@@ -105,7 +105,7 @@ uint32_t nvnc_fb_get_fourcc_format(const struct nvnc_fb* fb)
 	return fb->fourcc_format;
 }
 
-void nvnc__fb_free(struct nvnc_fb* fb)
+static void nvnc__fb_free(struct nvnc_fb* fb)
 {
 	free(fb->addr);
 	free(fb);

--- a/src/fb.c
+++ b/src/fb.c
@@ -57,19 +57,6 @@ struct nvnc_fb* nvnc_fb_new(uint16_t width, uint16_t height,
 }
 
 EXPORT
-bool nvnc_fb_lock(struct nvnc_fb* fb)
-{
-	bool expected = false;
-	return atomic_compare_exchange_strong(&fb->is_locked, &expected, true);
-}
-
-EXPORT
-void nvnc_fb_unlock(struct nvnc_fb* fb)
-{
-	fb->is_locked = false;
-}
-
-EXPORT
 enum nvnc_fb_flags nvnc_fb_get_flags(const struct nvnc_fb* fb)
 {
 	return fb->flags;

--- a/src/pixels.c
+++ b/src/pixels.c
@@ -15,6 +15,7 @@
  */
 
 #include "rfb-proto.h"
+#include "pixels.h"
 #include <stdlib.h>
 #include <assert.h>
 #include <libdrm/drm_fourcc.h>

--- a/src/raw-encoding.c
+++ b/src/raw-encoding.c
@@ -19,13 +19,15 @@
 #include "vec.h"
 #include "fb.h"
 #include "pixels.h"
+#include "raw-encoding.h"
 
 #include <pixman.h>
 
-int raw_encode_box(struct vec* dst, const struct rfb_pixel_format* dst_fmt,
-                   const struct nvnc_fb* fb,
-                   const struct rfb_pixel_format* src_fmt, int x_start,
-                   int y_start, int stride, int width, int height)
+static int raw_encode_box(struct vec* dst,
+                          const struct rfb_pixel_format* dst_fmt,
+                          const struct nvnc_fb* fb,
+                          const struct rfb_pixel_format* src_fmt, int x_start,
+                          int y_start, int stride, int width, int height)
 {
 	int rc = -1;
 

--- a/src/server.c
+++ b/src/server.c
@@ -772,7 +772,7 @@ accept_failure:
 	log_debug("Failed to accept a connection\n");
 }
 
-int bind_address(const char* name, int port)
+static int bind_address(const char* name, int port)
 {
 	struct addrinfo hints = {
 		.ai_socktype = SOCK_STREAM,
@@ -811,7 +811,7 @@ failure:
 	return fd;
 }
 
-bool nvnc__is_damaged(struct nvnc* self)
+static bool nvnc__is_damaged(struct nvnc* self)
 {
 	struct nvnc_client* client;
 	LIST_FOREACH(client, &self->clients, link)
@@ -821,7 +821,7 @@ bool nvnc__is_damaged(struct nvnc* self)
 	return false;
 }
 
-void on_main_dispatch(void* aml_obj)
+static void on_main_dispatch(void* aml_obj)
 {
 	struct nvnc* self = aml_get_userdata(aml_obj);
 	struct nvnc_client* client;
@@ -925,7 +925,7 @@ static void on_write_frame_done(void* userdata, enum stream_req_status status)
 	client_unref(client);
 }
 
-enum rfb_encodings choose_frame_encoding(struct nvnc_client* client)
+static enum rfb_encodings choose_frame_encoding(struct nvnc_client* client)
 {
 	for (size_t i = 0; i < client->n_encodings; ++i)
 		switch (client->encodings[i]) {
@@ -942,7 +942,7 @@ enum rfb_encodings choose_frame_encoding(struct nvnc_client* client)
 	return -1;
 }
 
-void do_client_update_fb(void* work)
+static void do_client_update_fb(void* work)
 {
 	struct fb_update_work* update = aml_get_userdata(work);
 	struct nvnc_client* client = update->client;
@@ -981,7 +981,7 @@ void do_client_update_fb(void* work)
 	}
 }
 
-void on_client_update_fb_done(void* work)
+static void on_client_update_fb_done(void* work)
 {
 	struct fb_update_work* update = aml_get_userdata(work);
 	struct nvnc_client* client = update->client;

--- a/src/stream.c
+++ b/src/stream.c
@@ -120,7 +120,7 @@ static int stream__flush_plain(struct stream* self)
 			break;
 	}
 
-	if (n_msgs < 0)
+	if (n_msgs == 0)
 		return 0;
 
 	bytes_sent = writev(self->fd, iov, n_msgs);

--- a/src/stream.c
+++ b/src/stream.c
@@ -54,7 +54,8 @@ static inline void stream__poll_rw(struct stream* self)
 	aml_set_event_mask(self->handler, POLLIN | POLLOUT);
 }
 
-static void stream_req__finish(struct stream_req* req, enum stream_req_status status)
+static void stream_req__finish(struct stream_req* req,
+                               enum stream_req_status status)
 {
 	if (req->on_done)
 		req->on_done(req->userdata, status);
@@ -332,7 +333,7 @@ int stream_write(struct stream* self, const void* payload, size_t len,
 	return buf ? stream_send(self, buf, on_done, userdata) : -1;
 }
 
-ssize_t stream__read_plain(struct stream* self, void* dst, size_t size)
+static ssize_t stream__read_plain(struct stream* self, void* dst, size_t size)
 {
 	ssize_t rc = read(self->fd, dst, size);
 	if (rc == 0)
@@ -341,7 +342,7 @@ ssize_t stream__read_plain(struct stream* self, void* dst, size_t size)
 }
 
 #ifdef ENABLE_TLS
-ssize_t stream__read_tls(struct stream* self, void* dst, size_t size)
+static ssize_t stream__read_tls(struct stream* self, void* dst, size_t size)
 {
 	ssize_t rc = gnutls_record_recv(self->tls_session, dst, size);
 	if (rc >= 0)

--- a/src/tight.c
+++ b/src/tight.c
@@ -38,7 +38,7 @@
 
 #define TIGHT_MAX_WIDTH 2048
 
-enum tight_quality tight_get_quality(struct tight_encoder* self)
+static enum tight_quality tight_get_quality(struct tight_encoder* self)
 {
 	struct nvnc_client* client =
 		container_of(self, struct nvnc_client, tight_encoder);
@@ -59,7 +59,7 @@ enum tight_quality tight_get_quality(struct tight_encoder* self)
 	return TIGHT_QUALITY_LOSSLESS;
 }
 
-int tight_init_zstream(z_stream* zx)
+static int tight_init_zstream(z_stream* zx)
 {
 	int rc = deflateInit2(zx,
 	                      /* compression level: */ 1,
@@ -87,7 +87,7 @@ static int calc_bytes_per_cpixel(const struct rfb_pixel_format* fmt)
 	                                 : fmt->bits_per_pixel / 8;
 }
 
-enum TJPF get_jpeg_pixfmt(uint32_t fourcc)
+static enum TJPF get_jpeg_pixfmt(uint32_t fourcc)
 {
 	switch (fourcc) {
 	case DRM_FORMAT_RGBA8888:
@@ -116,9 +116,9 @@ static void tight_encode_size(struct vec* dst, size_t size)
 		vec_fast_append_8(dst, (size >> 14) & 0xff);
 }
 
-int tight_encode_box_jpeg(struct tight_encoder* self, struct vec* dst,
-                          const struct nvnc_fb* fb, uint32_t x, uint32_t y,
-                          uint32_t stride, uint32_t width, uint32_t height)
+static int tight_encode_box_jpeg(struct tight_encoder* self, struct vec* dst,
+				 const struct nvnc_fb* fb, uint32_t x, uint32_t y,
+				 uint32_t stride, uint32_t width, uint32_t height)
 {
 
 	unsigned char* buffer = NULL;
@@ -176,7 +176,8 @@ compress_failure:
 	return rc;
 }
 
-int tight_deflate(struct vec* dst, void* src, size_t len, z_stream* zs, bool flush)
+static int tight_deflate(struct vec* dst, void* src, size_t len, z_stream* zs,
+                         bool flush)
 {
 	zs->next_in = src;
 	zs->avail_in = len;
@@ -200,11 +201,11 @@ int tight_deflate(struct vec* dst, void* src, size_t len, z_stream* zs, bool flu
 	return 0;
 }
 
-int tight_encode_box_basic(struct tight_encoder* self, struct vec* dst,
-                           const struct nvnc_fb* fb,
-                           const struct rfb_pixel_format* src_fmt,
-                           uint32_t x, uint32_t y_start,
-                           uint32_t stride, uint32_t width, uint32_t height)
+static int tight_encode_box_basic(struct tight_encoder* self, struct vec* dst,
+                                  const struct nvnc_fb* fb,
+                                  const struct rfb_pixel_format* src_fmt,
+                                  uint32_t x, uint32_t y_start, uint32_t stride,
+                                  uint32_t width, uint32_t height)
 {
 	struct nvnc_client* client =
 		container_of(self, struct nvnc_client, tight_encoder);
@@ -268,11 +269,11 @@ buffer_failure:
 	return -1;
 }
 
-int tight_encode_box(struct tight_encoder* self, struct vec* dst,
-                     const struct nvnc_fb* fb,
-                     const struct rfb_pixel_format* src_fmt,
-                     uint32_t x, uint32_t y,
-                     uint32_t stride, uint32_t width, uint32_t height)
+static int tight_encode_box(struct tight_encoder* self, struct vec* dst,
+			    const struct nvnc_fb* fb,
+			    const struct rfb_pixel_format* src_fmt,
+			    uint32_t x, uint32_t y,
+			    uint32_t stride, uint32_t width, uint32_t height)
 {
 	switch (self->quality) {
 	case TIGHT_QUALITY_LOSSLESS:

--- a/src/zrle.c
+++ b/src/zrle.c
@@ -49,7 +49,8 @@ static inline int calc_bytes_per_cpixel(const struct rfb_pixel_format* fmt)
 	                                 : fmt->bits_per_pixel / 8;
 }
 
-int zrle_get_tile_palette(uint32_t* palette, const uint32_t* src, size_t length)
+static int zrle_get_tile_palette(uint32_t* palette, const uint32_t* src,
+                                 size_t length)
 {
 	int n = 0;
 
@@ -70,10 +71,10 @@ int zrle_get_tile_palette(uint32_t* palette, const uint32_t* src, size_t length)
 	return n;
 }
 
-void zrle_encode_unichrome_tile(struct vec* dst,
-                                const struct rfb_pixel_format* dst_fmt,
-                                uint32_t colour,
-                                const struct rfb_pixel_format* src_fmt)
+static void zrle_encode_unichrome_tile(struct vec* dst,
+                                       const struct rfb_pixel_format* dst_fmt,
+                                       uint32_t colour,
+                                       const struct rfb_pixel_format* src_fmt)
 {
 	int bytes_per_cpixel = calc_bytes_per_cpixel(dst_fmt);
 
@@ -85,7 +86,7 @@ void zrle_encode_unichrome_tile(struct vec* dst,
 	dst->len += bytes_per_cpixel;
 }
 
-void encode_run_length(struct vec* dst, uint8_t index, int run_length)
+static void encode_run_length(struct vec* dst, uint8_t index, int run_length)
 {
 	if (run_length == 1) {
 		vec_fast_append_8(dst, index);
@@ -102,11 +103,12 @@ void encode_run_length(struct vec* dst, uint8_t index, int run_length)
 	vec_fast_append_8(dst, run_length - 1);
 }
 
-void zrle_encode_packed_tile(struct vec* dst,
-                             const struct rfb_pixel_format* dst_fmt,
-                             const uint32_t* src,
-                             const struct rfb_pixel_format* src_fmt,
-                             size_t length, uint32_t* palette, int palette_size)
+static void zrle_encode_packed_tile(struct vec* dst,
+                                    const struct rfb_pixel_format* dst_fmt,
+                                    const uint32_t* src,
+                                    const struct rfb_pixel_format* src_fmt,
+                                    size_t length, uint32_t* palette,
+                                    int palette_size)
 {
 	int bytes_per_cpixel = calc_bytes_per_cpixel(dst_fmt);
 
@@ -139,16 +141,18 @@ void zrle_encode_packed_tile(struct vec* dst,
 	}
 }
 
-void zrle_copy_tile(uint32_t* dst, const uint32_t* src, int stride, int width,
-                    int height)
+static void zrle_copy_tile(uint32_t* dst, const uint32_t* src, int stride,
+                           int width, int height)
 {
 	for (int y = 0; y < height; ++y)
 		memcpy(dst + y * width, src + y * stride, width * 4);
 }
 
-void zrle_encode_tile(struct vec* dst, const struct rfb_pixel_format* dst_fmt,
-                      const uint32_t* src,
-                      const struct rfb_pixel_format* src_fmt, size_t length)
+static void zrle_encode_tile(struct vec* dst,
+                             const struct rfb_pixel_format* dst_fmt,
+                             const uint32_t* src,
+                             const struct rfb_pixel_format* src_fmt,
+                             size_t length)
 {
 	int bytes_per_cpixel = calc_bytes_per_cpixel(dst_fmt);
 
@@ -176,7 +180,8 @@ void zrle_encode_tile(struct vec* dst, const struct rfb_pixel_format* dst_fmt,
 	dst->len += bytes_per_cpixel * length;
 }
 
-int zrle_deflate(struct vec* dst, const struct vec* src, z_stream* zs, bool flush)
+static int zrle_deflate(struct vec* dst, const struct vec* src, z_stream* zs,
+                        bool flush)
 {
 	zs->next_in = src->data;
 	zs->avail_in = src->len;
@@ -200,10 +205,11 @@ int zrle_deflate(struct vec* dst, const struct vec* src, z_stream* zs, bool flus
 	return 0;
 }
 
-int zrle_encode_box(struct vec* out, const struct rfb_pixel_format* dst_fmt,
-                    const struct nvnc_fb* fb,
-                    const struct rfb_pixel_format* src_fmt, int x, int y,
-                    int stride, int width, int height, z_stream* zs)
+static int zrle_encode_box(struct vec* out,
+                           const struct rfb_pixel_format* dst_fmt,
+                           const struct nvnc_fb* fb,
+                           const struct rfb_pixel_format* src_fmt, int x, int y,
+                           int stride, int width, int height, z_stream* zs)
 {
 	int r = -1;
 	int bytes_per_cpixel = calc_bytes_per_cpixel(dst_fmt);


### PR DESCRIPTION
Several changes which share the common goal to use `-Wmissing-prototypes` by default.