### PR TITLE
use memcpy if pixel format is the same

### DIFF
--- a/src/pixels.c
+++ b/src/pixels.c
@@ -36,6 +36,20 @@ void pixel32_to_cpixel(uint8_t* restrict dst,
 	assert(dst_fmt->depth <= 24);
 	assert(bytes_per_cpixel <= 4 && bytes_per_cpixel >= 1);
 
+	if (src_fmt->bits_per_pixel == dst_fmt->bits_per_pixel &&
+	    src_fmt->depth == dst_fmt->depth &&
+	    src_fmt->big_endian_flag == dst_fmt->big_endian_flag &&
+	    src_fmt->red_shift == dst_fmt->red_shift &&
+	    src_fmt->red_max == dst_fmt->red_max &&
+	    src_fmt->green_shift == dst_fmt->green_shift &&
+	    src_fmt->green_max == dst_fmt->green_max &&
+	    src_fmt->blue_shift == dst_fmt->blue_shift &&
+	    src_fmt->blue_max == dst_fmt->blue_max)
+	{
+		memcpy(dst, src, len * bytes_per_cpixel);
+		return;
+	}
+
 	uint32_t src_red_shift = src_fmt->red_shift;
 	uint32_t src_green_shift = src_fmt->green_shift;
 	uint32_t src_blue_shift = src_fmt->blue_shift;


### PR DESCRIPTION
Use memcpy if the pixel format of source and destination is the same.
This improves performance of raw encoding significantly in my test
case with Weston.