### PR TITLE
add proper build options (helps for building a package)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -88,7 +88,7 @@ if gnutls.found()
 	config.set('ENABLE_TLS', true)
 endif
 
-if host_system == 'linux' and cc.has_header('sys/sdt.h')
+if host_system == 'linux' and get_option('systemtap') and cc.has_header('sys/sdt.h')
 	config.set('HAVE_USDT', true)
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('benchmarks', type: 'boolean', value: false, description: 'Build benchmar
 option('examples', type: 'boolean', value: false, description: 'Build examples')
 option('jpeg', type: 'feature', value: 'auto', description: 'Enable JPEG compression')
 option('tls', type: 'feature', value: 'auto', description: 'Enable encryption & authentication')
+option('systemtap', type: 'boolean', value: false, description: 'Enable tracing using sdt')


### PR DESCRIPTION
- ~~add option for cpu optimizations~~
- add option for sys/std.h
- ~~remove aml as subdirectory and make proper dependency~~

~~This helps in packaging to gentoo as CPU specific optimizations will not work on all ARM/x86_64 platforms.~~

Signed-off-by: Aisha Tammy <gentoo@aisha.cc>