### PR TITLE
Allow consumers to link statically

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,7 @@ configure_file(
 	configuration: config,
 )
 
-neatvnc = shared_library(
+neatvnc = library(
 	'neatvnc',
 	sources,
 	version: '0.0.0',


### PR DESCRIPTION
Depends on https://github.com/any1/aml/pull/5. Downstream may pass `-Ddefault_library=static` (or `-Dneatvnc:default_library=static`) to avoid packaging dependencies.

See also https://mesonbuild.com/Build-targets.html
