### PR TITLE
support UNIX sockets

### DIFF
--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -54,6 +54,7 @@ typedef void (*nvnc_cut_text_fn)(struct nvnc*, const char* text, uint32_t len);
 extern const char nvnc_version[];
 
 struct nvnc* nvnc_open(const char* addr, uint16_t port);
+struct nvnc* nvnc_open_unix(const char *addr);
 void nvnc_close(struct nvnc* self);
 
 void nvnc_add_display(struct nvnc*, struct nvnc_display*);


### PR DESCRIPTION
Use an extended getaddrinfo_unix which will treat any absolute path
(i.e. address starting with '/') as a place to bind a UNIX domain
socket. Store the socket path in the main nvnc structure to allow for
cleanup on closure. Closes #1.