### PR TITLE
Don't call gbm symbols when they are not available

### DIFF
--- a/src/fb.c
+++ b/src/fb.c
@@ -184,7 +184,11 @@ static void nvnc__fb_free(struct nvnc_fb* fb)
 			free(fb->addr);
 			break;
 		case NVNC_FB_GBM_BO:
+#ifdef HAVE_GBM
 			gbm_bo_destroy(fb->bo);
+#else
+			abort();
+#endif
 			break;
 		}
 


### PR DESCRIPTION
I got

```
/usr/bin/ld: subprojects/neatvnc/libneatvnc.so.0.0.0.p/src_fb.c.o: in function `nvnc__fb_free':
/home/harmth/gits/wayvnc/build/../subprojects/neatvnc/src/fb.c:187: undefined reference to `gbm_bo_destroy'
collect2: error: ld returned 1 exit status
[68/71] Compiling C object wayvnc.p/src_main.c.o
ninja: build stopped: subcommand failed.
```

while trying to compile neatvnc on Debian Bullseye aarch64.