### PR TITLE
Unbreak build on BSDs

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -46,6 +46,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <netinet/tcp.h>
 
 #ifdef ENABLE_TLS


### PR DESCRIPTION
Regressed by f20ffb5e1efe. `IPPROTO_TCP` requires `<netinet/in.h>` while `TCP_NODELAY` requires `<netinet/tcp.h>`, both on Linux (glibc, musl) and on BSDs (DragonFly, FreeBSD, NetBSD, OpenBSD). Likely missed due to header bootlegging. To investigate on Linux (where it builds fine "as is") inject `#error` into `<netinet/in.h>` to let compiler show intermediate headers.

See also https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html

```c
$ meson setup /tmp/neatvnc_build
$ meson compile -C /tmp/neatvnc_build
[...]
src/server.c:1119:17: error: use of undeclared identifier 'IPPROTO_TCP'
        setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
                       ^
```
