### PR TITLE
Allow to query client-side cursor support

### DIFF
--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -126,6 +126,7 @@ void nvnc_set_userdata(void* self, void* userdata, nvnc_cleanup_fn);
 void* nvnc_get_userdata(const void* self);
 
 struct nvnc* nvnc_client_get_server(const struct nvnc_client* client);
+bool nvnc_client_supports_cursor(const struct nvnc_client* client);
 
 void nvnc_set_name(struct nvnc* self, const char* name);
 

--- a/src/server.c
+++ b/src/server.c
@@ -1570,6 +1570,16 @@ struct nvnc* nvnc_client_get_server(const struct nvnc_client* client)
 }
 
 EXPORT
+bool nvnc_client_supports_cursor(const struct nvnc_client* client)
+{
+	for (size_t i = 0; i < client->n_encodings; ++i) {
+		if (client->encodings[i] == RFB_ENCODING_CURSOR)
+			return true;
+	}
+	return false;
+}
+
+EXPORT
 void nvnc_set_name(struct nvnc* self, const char* name)
 {
 	strncpy(self->name, name, sizeof(self->name));


### PR DESCRIPTION
Add a function nvnc_client_supports_cursor() to enable the API user to make an informed decision whether nvnc_set_cursor() can be expected to make the client draw the cursor, or whether it has to be rendered into the framebuffer.