### PR TITLE
Add missing dependency on libavutil if found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -114,14 +114,11 @@ if gbm.found()
 	config.set('HAVE_GBM', true)
 endif
 
-if libavutil.found()
-	config.set('HAVE_LIBAVUTIL', true)
-endif
-
 if gbm.found() and libdrm.found() and libavcodec.found() and libavfilter.found() and libavutil.found()
 	sources += [ 'src/h264-encoder.c', 'src/open-h264.c' ]
 	dependencies += [libdrm, libavcodec, libavfilter, libavutil]
 	config.set('ENABLE_OPEN_H264', true)
+	config.set('HAVE_LIBAVUTIL', true)
 endif
 
 configure_file(


### PR DESCRIPTION
`src/log.c` uses `av_log_set_level()` and `av_log_set_callback()` from libavutil if `HAVE_LIBAVUTIL` is set. This causes a build failure if libavutils development packages are installed, but the other dependencies for h264 are not.