### PR TITLE
Fix fallthrough warnings in murmurhash

### DIFF
--- a/src/murmurhash.c
+++ b/src/murmurhash.c
@@ -69,8 +69,9 @@ murmurhash (const char *key, uint32_t len, uint32_t seed) {
   // remainder
   switch (len & 3) { // `len % 4'
     case 3: k ^= (tail[2] << 16);
+      // fallthrough
     case 2: k ^= (tail[1] << 8);
-
+      // fallthrough
     case 1:
       k ^= tail[0];
       k *= c1;


### PR DESCRIPTION
Fix two -Wimplicit-fallthrough warnings in the murmurhash function:
```
../src/murmurhash.c: In function 'murmurhash':
../src/murmurhash.c:71:15: warning: this statement may fall through [-Wimplicit-fallthrough=]
   71 |     case 3: k ^= (tail[2] << 16);
      |             ~~^~~~~~~~~~~~~~~~~~
../src/murmurhash.c:72:5: note: here
   72 |     case 2: k ^= (tail[1] << 8);
      |     ^~~~
../src/murmurhash.c:72:15: warning: this statement may fall through [-Wimplicit-fallthrough=]
   72 |     case 2: k ^= (tail[1] << 8);
      |             ~~^~~~~~~~~~~~~~~~~
../src/murmurhash.c:74:5: note: here
   74 |     case 1:
      |     ^~~~
```