### PR TITLE
Record client hostname and username

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -70,6 +70,7 @@ struct nvnc_client {
 	int ref;
 	struct stream* net_stream;
 	char hostname[256];
+	char username[256];
 	struct nvnc* server;
 	enum nvnc_client_state state;
 	bool has_pixfmt;

--- a/include/common.h
+++ b/include/common.h
@@ -69,6 +69,7 @@ struct nvnc_client {
 	struct nvnc_common common;
 	int ref;
 	struct stream* net_stream;
+	char hostname[256];
 	struct nvnc* server;
 	enum nvnc_client_state state;
 	bool has_pixfmt;

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -131,6 +131,7 @@ void* nvnc_get_userdata(const void* self);
 
 struct nvnc* nvnc_client_get_server(const struct nvnc_client* client);
 bool nvnc_client_supports_cursor(const struct nvnc_client* client);
+const char* nvnc_client_get_hostname(const struct nvnc_client* client);
 
 void nvnc_set_name(struct nvnc* self, const char* name);
 

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -132,6 +132,7 @@ void* nvnc_get_userdata(const void* self);
 struct nvnc* nvnc_client_get_server(const struct nvnc_client* client);
 bool nvnc_client_supports_cursor(const struct nvnc_client* client);
 const char* nvnc_client_get_hostname(const struct nvnc_client* client);
+const char* nvnc_client_get_auth_username(const struct nvnc_client* client);
 
 void nvnc_set_name(struct nvnc* self, const char* name);
 

--- a/src/server.c
+++ b/src/server.c
@@ -331,6 +331,9 @@ static int on_vencrypt_plain_auth_message(struct nvnc_client* client)
 	username[MIN(ulen, sizeof(username) - 1)] = '\0';
 	password[MIN(plen, sizeof(password) - 1)] = '\0';
 
+	strncpy(client->username, username, sizeof(client->username));
+	client->username[sizeof(client->username) - 1] = '\0';
+
 	if (server->auth_fn(username, password, server->auth_ud)) {
 		nvnc_log(NVNC_LOG_INFO, "User \"%s\" authenticated", username);
 		security_handshake_ok(client);
@@ -1629,6 +1632,13 @@ const char* nvnc_client_get_hostname(const struct nvnc_client* client) {
 	if (client->hostname[0] == '\0')
 		return NULL;
 	return client->hostname;
+}
+
+EXPORT
+const char* nvnc_client_get_auth_username(const struct nvnc_client* client) {
+	if (client->username[0] == '\0')
+		return NULL;
+	return client->username;
 }
 
 EXPORT


### PR DESCRIPTION
- Record peer hostname for each connected client
- Record authenticated username for each connected client

Both of these are best-effort, and may not be available for all clients.
