### PR TITLE
Desktop resizing

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -110,6 +110,7 @@ struct nvnc {
 	nvnc_fb_req_fn fb_req_fn;
 	nvnc_client_fn new_client_fn;
 	nvnc_cut_text_fn cut_text_fn;
+	nvnc_desktop_layout_fn desktop_layout_fn;
 	struct nvnc_display* display;
 	struct {
 		struct nvnc_fb* buffer;

--- a/include/desktop-layout.h
+++ b/include/desktop-layout.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 Philipp Zabel
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+struct nvnc_display;
+struct rfb_screen;
+
+struct nvnc_display_layout {
+	struct nvnc_display* display;
+	uint32_t id;
+	uint16_t x_pos, y_pos;
+	uint16_t width, height;
+};
+
+struct nvnc_desktop_layout {
+	uint16_t width, height;
+	uint8_t n_display_layouts;
+	struct nvnc_display_layout display_layouts[0];
+};
+
+void nvnc_display_layout_init(
+		struct nvnc_display_layout* display, struct rfb_screen* screen);

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -50,6 +50,7 @@
 
 struct nvnc;
 struct nvnc_client;
+struct nvnc_desktop_layout;
 struct nvnc_display;
 struct nvnc_fb;
 struct nvnc_fb_pool;
@@ -117,6 +118,8 @@ typedef struct nvnc_fb* (*nvnc_fb_alloc_fn)(uint16_t width, uint16_t height,
 		uint32_t format, uint16_t stride);
 typedef void (*nvnc_cleanup_fn)(void* userdata);
 typedef void (*nvnc_log_fn)(const struct nvnc_log_data*, const char* message);
+typedef bool (*nvnc_desktop_layout_fn)(
+		struct nvnc_client*, const struct nvnc_desktop_layout*);
 
 extern const char nvnc_version[];
 
@@ -148,6 +151,7 @@ void nvnc_set_fb_req_fn(struct nvnc* self, nvnc_fb_req_fn);
 void nvnc_set_new_client_fn(struct nvnc* self, nvnc_client_fn);
 void nvnc_set_client_cleanup_fn(struct nvnc_client* self, nvnc_client_fn fn);
 void nvnc_set_cut_text_fn(struct nvnc*, nvnc_cut_text_fn fn);
+void nvnc_set_desktop_layout_fn(struct nvnc* self, nvnc_desktop_layout_fn);
 
 bool nvnc_has_auth(void);
 int nvnc_enable_auth(struct nvnc* self, const char* privkey_path,
@@ -201,6 +205,20 @@ struct nvnc* nvnc_display_get_server(const struct nvnc_display*);
 
 void nvnc_display_feed_buffer(struct nvnc_display*, struct nvnc_fb*,
 			      struct pixman_region16* damage);
+
+uint16_t nvnc_desktop_layout_get_width(const struct nvnc_desktop_layout*);
+uint16_t nvnc_desktop_layout_get_height(const struct nvnc_desktop_layout*);
+uint8_t nvnc_desktop_layout_get_display_count(const struct nvnc_desktop_layout*);
+uint16_t nvnc_desktop_layout_get_display_x_pos(
+		const struct nvnc_desktop_layout*, uint8_t display_index);
+uint16_t nvnc_desktop_layout_get_display_y_pos(
+		const struct nvnc_desktop_layout*, uint8_t display_index);
+uint16_t nvnc_desktop_layout_get_display_width(
+		const struct nvnc_desktop_layout*, uint8_t display_index);
+uint16_t nvnc_desktop_layout_get_display_height(
+		const struct nvnc_desktop_layout*, uint8_t display_index);
+struct nvnc_display* nvnc_desktop_layout_get_display(
+		const struct nvnc_desktop_layout*, uint8_t display_index);
 
 void nvnc_send_cut_text(struct nvnc*, const char* text, uint32_t len);
 

--- a/include/rfb-proto.h
+++ b/include/rfb-proto.h
@@ -45,6 +45,7 @@ enum rfb_client_to_server_msg_type {
 	RFB_CLIENT_TO_SERVER_KEY_EVENT = 4,
 	RFB_CLIENT_TO_SERVER_POINTER_EVENT = 5,
 	RFB_CLIENT_TO_SERVER_CLIENT_CUT_TEXT = 6,
+	RFB_CLIENT_TO_SERVER_SET_DESKTOP_SIZE = 251,
 	RFB_CLIENT_TO_SERVER_QEMU = 255,
 };
 
@@ -64,6 +65,7 @@ enum rfb_encodings {
 	RFB_ENCODING_CURSOR = -239,
 	RFB_ENCODING_DESKTOPSIZE = -223,
 	RFB_ENCODING_QEMU_EXT_KEY_EVENT = -258,
+	RFB_ENCODING_EXTENDEDDESKTOPSIZE = -308,
 	RFB_ENCODING_PTS = -1000,
 };
 
@@ -85,6 +87,20 @@ enum rfb_vencrypt_subtype {
 	RFB_VENCRYPT_X509_NONE,
 	RFB_VENCRYPT_X509_VNC,
 	RFB_VENCRYPT_X509_PLAIN,
+};
+
+enum rfb_resize_initiator {
+	RFB_RESIZE_INITIATOR_SERVER = 0,
+	RFB_RESIZE_INITIATOR_THIS_CLIENT = 1,
+	RFB_RESIZE_INITIATOR_OTHER_CLIENT = 2,
+};
+
+enum rfb_resize_status {
+	RFB_RESIZE_STATUS_SUCCESS = 0,
+	RFB_RESIZE_STATUS_PROHIBITED = 1,
+	RFB_RESIZE_STATUS_OUT_OF_RESOURCES = 2,
+	RFB_RESIZE_STATUS_INVALID_LAYOUT = 3,
+	RFB_RESIZE_STATUS_REQUEST_FORWARDED = 4,
 };
 
 struct rfb_security_types_msg {
@@ -170,6 +186,25 @@ struct rfb_server_fb_rect {
 	uint16_t width;
 	uint16_t height;
 	int32_t encoding;
+} RFB_PACKED;
+
+struct rfb_screen {
+	uint32_t id;
+	uint16_t x;
+	uint16_t y;
+	uint16_t width;
+	uint16_t height;
+	uint32_t flags;
+} RFB_PACKED;
+
+struct rfb_client_set_desktop_size_event_msg {
+	uint8_t type;
+	uint8_t padding;
+	uint16_t width;
+	uint16_t height;
+	uint8_t number_of_screens;
+	uint8_t padding2;
+	struct rfb_screen screens[0];
 } RFB_PACKED;
 
 struct rfb_server_fb_update_msg {

--- a/meson.build
+++ b/meson.build
@@ -77,6 +77,7 @@ sources = [
 	'src/fb_pool.c',
 	'src/rcbuf.c',
 	'src/stream.c',
+	'src/desktop-layout.c',
 	'src/display.c',
 	'src/tight.c',
 	'src/enc-util.c',

--- a/src/desktop-layout.c
+++ b/src/desktop-layout.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Philipp Zabel
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "desktop-layout.h"
+#include "neatvnc.h"
+#include "rfb-proto.h"
+
+#define EXPORT __attribute__((visibility("default")))
+
+void nvnc_display_layout_init(
+		struct nvnc_display_layout* display, struct rfb_screen* screen)
+{
+	display->display = NULL;
+	display->id = ntohl(screen->id);
+	display->x_pos = ntohs(screen->x);
+	display->y_pos = ntohs(screen->y);
+	display->width = ntohs(screen->width);
+	display->height = ntohs(screen->height);
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_width(const struct nvnc_desktop_layout* layout)
+{
+	return layout->width;
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_height(const struct nvnc_desktop_layout* layout)
+{
+	return layout->height;
+}
+
+EXPORT
+uint8_t nvnc_desktop_layout_get_display_count(
+		const struct nvnc_desktop_layout* layout)
+{
+	return layout->n_display_layouts;
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_display_x_pos(
+		const struct nvnc_desktop_layout* layout, uint8_t display_index)
+{
+	if (display_index >= layout->n_display_layouts)
+		return 0;
+	return layout->display_layouts[display_index].x_pos;
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_display_y_pos(
+		const struct nvnc_desktop_layout* layout, uint8_t display_index)
+{
+	if (display_index >= layout->n_display_layouts)
+		return 0;
+	return layout->display_layouts[display_index].y_pos;
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_display_width(
+		const struct nvnc_desktop_layout* layout, uint8_t display_index)
+{
+	if (display_index >= layout->n_display_layouts)
+		return 0;
+	return layout->display_layouts[display_index].width;
+}
+
+EXPORT
+uint16_t nvnc_desktop_layout_get_display_height(
+		const struct nvnc_desktop_layout* layout, uint8_t display_index)
+{
+	if (display_index >= layout->n_display_layouts)
+		return 0;
+	return layout->display_layouts[display_index].height;
+}
+
+EXPORT
+struct nvnc_display* nvnc_desktop_layout_get_display(
+		const struct nvnc_desktop_layout* layout, uint8_t display_index)
+{
+	if (display_index >= layout->n_display_layouts)
+		return NULL;
+	return layout->display_layouts[display_index].display;
+}


### PR DESCRIPTION
Implement minimal desktop resizing support and demonstrate it in the draw example, tested with TigerVNC.

This uses the [ExtendedDesktopSize](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#7713extendeddesktopsize-pseudo-encoding) pseudo-encoding to let clients know that they may issue [SetDesktopSize](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#7410setdesktopsize) messages. Neat VNC reports those via the `nvnc_desktop_size_fn` callback. Right now the callback is not prepared for multi-display support (the screen layout structures are not passed in) and it can't report back the _out-of-resources_ or _request-forwarded (async)_ status codes - a return value of `true` maps to _no-error_ and `false` maps to _resize-administratively-prohibited_.