### PR TITLE
NVidia Tight encoder fix

### DIFF
--- a/include/pixels.h
+++ b/include/pixels.h
@@ -23,9 +23,9 @@
 
 struct rfb_pixel_format;
 
-void pixel32_to_cpixel(uint8_t* restrict dst,
+void pixel_to_cpixel(uint8_t* restrict dst,
                        const struct rfb_pixel_format* dst_fmt,
-                       const uint32_t* restrict src,
+                       const uint8_t* restrict src,
                        const struct rfb_pixel_format* src_fmt,
                        size_t bytes_per_cpixel, size_t len);
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -94,12 +94,14 @@ int cursor_encode(struct vec* dst, struct rfb_pixel_format* pixfmt,
 	uint8_t* dstdata = dst->data;
 	dstdata += dst->len;
 
+	int32_t src_byte_stride = image->stride * (srcfmt.bits_per_pixel / 8);
+
 	if((int32_t)width == image->stride) {
-		pixel32_to_cpixel(dstdata, pixfmt, image->addr, &srcfmt, bpp, size);
+		pixel_to_cpixel(dstdata, pixfmt, image->addr, &srcfmt, bpp, size);
 	} else {
 		for (uint32_t y = 0; y < height; ++y) {
-			pixel32_to_cpixel(dstdata + y * bpp * width, pixfmt,
-					(uint32_t*)image->addr + y * image->stride,
+			pixel_to_cpixel(dstdata + y * bpp * width, pixfmt,
+					(uint8_t*)image->addr + y * src_byte_stride,
 					&srcfmt, bpp, width);
 		}
 	}

--- a/src/fb.c
+++ b/src/fb.c
@@ -41,6 +41,8 @@ struct nvnc_fb* nvnc_fb_new(uint16_t width, uint16_t height,
 	if (!fb)
 		return NULL;
 
+	uint32_t bpp = pixel_size_from_fourcc(fourcc_format);
+
 	fb->type = NVNC_FB_SIMPLE;
 	fb->ref = 1;
 	fb->width = width;
@@ -49,7 +51,7 @@ struct nvnc_fb* nvnc_fb_new(uint16_t width, uint16_t height,
 	fb->stride = stride;
 	fb->pts = NVNC_NO_PTS;
 
-	size_t size = height * stride * 4; /* Assume 4 byte format for now */
+	size_t size = height * stride * bpp;
 	size_t alignment = MAX(4, sizeof(void*));
 	size_t aligned_size = ALIGN_UP(size, alignment);
 

--- a/src/raw-encoding.c
+++ b/src/raw-encoding.c
@@ -69,7 +69,10 @@ static int raw_encode_box(struct raw_encoder_work* ctx, struct vec* dst,
 	if (rc < 0)
 		return -1;
 
-	uint32_t* b = fb->addr;
+	uint8_t* b = fb->addr;
+	int32_t src_bpp = src_fmt->bits_per_pixel / 8;
+	int32_t xoff = x_start * src_bpp;
+	int32_t src_stride = fb->stride * src_bpp;
 
 	int bpp = dst_fmt->bits_per_pixel / 8;
 
@@ -80,8 +83,8 @@ static int raw_encode_box(struct raw_encoder_work* ctx, struct vec* dst,
 	uint8_t* d = dst->data;
 
 	for (int y = y_start; y < y_start + height; ++y) {
-		pixel32_to_cpixel(d + dst->len, dst_fmt,
-		                  b + x_start + y * stride, src_fmt,
+		pixel_to_cpixel(d + dst->len, dst_fmt,
+		                  b + xoff + y * src_stride, src_fmt,
 		                  bpp, width);
 		dst->len += width * bpp;
 	}
@@ -131,7 +134,7 @@ static void raw_encoder_do_work(void* obj)
 	struct nvnc_fb* fb = ctx->fb;
 	assert(fb);
 
-	size_t bpp = nvnc_fb_get_pixel_size(fb);
+	size_t bpp = ctx->output_format.bits_per_pixel / 8;
 	size_t n_rects = pixman_region_n_rects(&ctx->damage);
 	if (n_rects > UINT16_MAX)
 		n_rects = 1;

--- a/src/zrle.c
+++ b/src/zrle.c
@@ -102,7 +102,7 @@ static void zrle_encode_unichrome_tile(struct vec* dst,
 
 	vec_fast_append_8(dst, 1);
 
-	pixel32_to_cpixel(((uint8_t*)dst->data) + 1, dst_fmt, &colour, src_fmt,
+	pixel_to_cpixel(((uint8_t*)dst->data) + 1, dst_fmt, (uint8_t*)&colour, src_fmt,
 	                  bytes_per_cpixel, 1);
 
 	dst->len += bytes_per_cpixel;
@@ -135,7 +135,7 @@ static void zrle_encode_packed_tile(struct vec* dst,
 	int bytes_per_cpixel = calc_bytes_per_cpixel(dst_fmt);
 
 	uint8_t cpalette[16 * 3];
-	pixel32_to_cpixel((uint8_t*)cpalette, dst_fmt, palette, src_fmt,
+	pixel_to_cpixel((uint8_t*)cpalette, dst_fmt, (uint8_t*)palette, src_fmt,
 	                  bytes_per_cpixel, palette_size);
 
 	vec_fast_append_8(dst, 128 | palette_size);
@@ -196,7 +196,7 @@ static void zrle_encode_tile(struct vec* dst,
 
 	vec_fast_append_8(dst, 0);
 
-	pixel32_to_cpixel(((uint8_t*)dst->data) + 1, dst_fmt, src, src_fmt,
+	pixel_to_cpixel(((uint8_t*)dst->data) + 1, dst_fmt, (uint8_t*)src, src_fmt,
 	                  bytes_per_cpixel, length);
 
 	dst->len += bytes_per_cpixel * length;

--- a/test/test-pixels.c
+++ b/test/test-pixels.c
@@ -22,10 +22,11 @@
 #define UDIV_UP(a, b) (((a) + (b) - 1) / (b))
 #define ARRAY_LEN(a) (sizeof(a) / (sizeof(a[0])))
 
-static bool test_pixel32_to_cpixel_4bpp(void)
+static bool test_pixel_to_cpixel_4bpp(void)
 {
 	uint32_t src = u32_le(0x11223344u);
 	uint32_t dst;
+	uint8_t* src_addr = (uint8_t*)&src;
 
 	struct rfb_pixel_format dstfmt = { 0 }, srcfmt = { 0 };
 
@@ -33,25 +34,63 @@ static bool test_pixel32_to_cpixel_4bpp(void)
 
 	dst = 0;
 	rfb_pixfmt_from_fourcc(&srcfmt, DRM_FORMAT_RGBA8888);
-	pixel32_to_cpixel((uint8_t*)&dst, &dstfmt, &src, &srcfmt, 4, 1);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
 	if ((src & 0xffffff00u) != (dst & 0xffffff00u))
 		return false;
 
 	dst = 0;
 	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_ABGR8888);
-	pixel32_to_cpixel((uint8_t*)&dst, &dstfmt, &src, &srcfmt, 4, 1);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
 	if (dst != u32_le(0x00332211u))
 		return false;
 
 	dst = 0;
 	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_ARGB8888);
-	pixel32_to_cpixel((uint8_t*)&dst, &dstfmt, &src, &srcfmt, 4, 1);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
 	if (dst != u32_le(0x00112233u))
 		return false;
 
 	dst = 0;
 	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_BGRA8888);
-	pixel32_to_cpixel((uint8_t*)&dst, &dstfmt, &src, &srcfmt, 4, 1);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
+	if (dst != u32_le(0x33221100u))
+		return false;
+
+	return true;
+}
+
+static bool test_pixel_to_cpixel_3bpp(void)
+{
+	//44 is extra data that should not be copied anywhere below.
+	uint32_t src = u32_le(0x44112233u);
+	uint32_t dst;
+	uint8_t* src_addr = (uint8_t*)&src;
+
+	struct rfb_pixel_format dstfmt = { 0 }, srcfmt = { 0 };
+
+	rfb_pixfmt_from_fourcc(&srcfmt, DRM_FORMAT_RGB888);
+
+	dst = 0;
+	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_RGBA8888);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
+	if (dst != u32_le(0x11223300u))
+		return false;
+
+	dst = 0;
+	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_ABGR8888);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
+	if (dst != u32_le(0x00332211u))
+		return false;
+
+	dst = 0;
+	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_ARGB8888);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
+	if (dst != u32_le(0x00112233u))
+		return false;
+
+	dst = 0;
+	rfb_pixfmt_from_fourcc(&dstfmt, DRM_FORMAT_BGRA8888);
+	pixel_to_cpixel((uint8_t*)&dst, &dstfmt, src_addr, &srcfmt, 4, 1);
 	if (dst != u32_le(0x33221100u))
 		return false;
 
@@ -173,7 +212,8 @@ static bool test_rfb_pixfmt_to_string(void)
 
 int main()
 {
-	bool ok = test_pixel32_to_cpixel_4bpp() &&
+	bool ok = test_pixel_to_cpixel_4bpp() &&
+		test_pixel_to_cpixel_3bpp() &&
 		test_fourcc_to_pixman_fmt() &&
 		test_extract_alpha_mask_rgba8888() &&
 		test_drm_format_to_string() &&


### PR DESCRIPTION
Summary:

## fb.h
- Added additional field "byte_stride"
## fb.c
- Add byte stride to fb which is the width of a row in bytes (not pixels)
- fb size is no longer just using 4 for pixel size
## pixel.c
- added new function to handle 24 bit source format
## tight.c: 
- addressing into the source data will now use bits per pixel to calculate offsets
## damage-refinery.c
- use similar addressing formula as in tight.c, no longer is the bpp constant to 4.
