### PR TITLE
Apply any1/wayvnc#248 patch

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -117,6 +117,9 @@ void nvnc_display_feed_buffer(struct nvnc_display* self, struct nvnc_fb* fb,
 	struct nvnc* server = self->server;
 	assert(server);
 
+	pixman_region_intersect_rect(damage, damage, 0, 0, fb->width,
+			fb->height);
+
 	struct pixman_region16 refined_damage;
 	pixman_region_init(&refined_damage);
 


### PR DESCRIPTION
Apply any1/wayvnc#248 [patch](https://github.com/any1/wayvnc/issues/248#issuecomment-1519036469) to avoid crashing when damage is drawn out of the screen.

Related issue hyprwm/Hyprland/issues/3723.