### PR TITLE
server: Remove undeclared variable from tracing macro

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -2109,7 +2109,7 @@ static void complete_fb_update(struct nvnc_client* client)
 	client->current_fb = NULL;
 	process_fb_update_requests(client);
 	client_unref(client);
-	DTRACE_PROBE2(neatvnc, update_fb_done, client, pts);
+	DTRACE_PROBE1(neatvnc, update_fb_done, client);
 }
 
 static void on_write_frame_done(void* userdata, enum stream_req_status status)


### PR DESCRIPTION
* 3647457f6d769fe3c9518078008ef56be58b70b1 accidentally referred to an nonexistant variable. This leads to build failure if you then enable the systemtap feature.
* Downstream bug https://bugs.gentoo.org/902141

I have read and understood CONTRIBUTING.md.