### PR TITLE
Extended Clipboard pseudo-encoding (UTF-8 text)

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -39,6 +39,7 @@
 #define MAX_OUTGOING_FRAMES 4
 #define MSG_BUFFER_SIZE 4096
 #define MAX_CUT_TEXT_SIZE 10000000
+#define MAX_CLIENT_UNSOLICITED_TEXT_SIZE 20971520
 #define MAX_SECURITY_TYPES 32
 
 enum nvnc_client_state {
@@ -79,6 +80,8 @@ struct cut_text {
 	char* buffer;
 	size_t length;
 	size_t index;
+	bool is_zlib;
+	bool is_provide;
 };
 
 struct nvnc_client {
@@ -104,6 +107,8 @@ struct nvnc_client {
 	uint32_t known_width;
 	uint32_t known_height;
 	struct cut_text cut_text;
+	uint32_t ext_clipboard_caps;
+	uint32_t ext_clipboard_max_unsolicited_text_size;
 	bool is_ext_notified;
 	struct encoder* encoder;
 	struct encoder* zrle_encoder;
@@ -150,6 +155,7 @@ struct nvnc {
 	nvnc_fb_req_fn fb_req_fn;
 	nvnc_client_fn new_client_fn;
 	nvnc_cut_text_fn cut_text_fn;
+	struct cut_text ext_clipboard_provide_msg;
 	nvnc_desktop_layout_fn desktop_layout_fn;
 	struct nvnc_display* display;
 	struct {

--- a/include/rfb-proto.h
+++ b/include/rfb-proto.h
@@ -74,6 +74,8 @@ enum rfb_encodings {
 	RFB_ENCODING_PTS = -1000,
 	RFB_ENCODING_NTP = -1001,
 	RFB_ENCODING_VMWARE_LED_STATE = 0x574d5668,
+	// 0xc0a1e5ce, greater than INT_MAX
+	RFB_ENCODING_EXTENDED_CLIPBOARD = -1063131698,
 };
 
 #define RFB_ENCODING_JPEG_HIGHQ -23
@@ -121,6 +123,24 @@ enum rfb_led_state {
 	RFB_LED_STATE_SCROLL_LOCK = 1 << 0,
 	RFB_LED_STATE_NUM_LOCK = 1 << 1,
 	RFB_LED_STATE_CAPS_LOCK = 1 << 2,
+};
+
+enum rfb_ext_clipboard_flags {
+	RFB_EXT_CLIPBOARD_FORMAT_TEXT = 1 << 0,
+	RFB_EXT_CLIPBOARD_FORMAT_RTF = 1 << 1,
+	RFB_EXT_CLIPBOARD_FORMAT_HTML = 1 << 2,
+	RFB_EXT_CLIPBOARD_FORMAT_DIB = 1 << 3,
+	RFB_EXT_CLIPBOARD_FORMAT_FILES = 1 << 4,
+	RFB_EXT_CLIPBOARD_CAPS = 1 << 24,
+	RFB_EXT_CLIPBOARD_ACTION_REQUEST = 1 << 25,
+	RFB_EXT_CLIPBOARD_ACTION_PEEK = 1 << 26,
+	RFB_EXT_CLIPBOARD_ACTION_NOTIFY = 1 << 27,
+	RFB_EXT_CLIPBOARD_ACTION_PROVIDE = 1 << 28,
+	RFB_EXT_CLIPBOARD_ACTION_ALL =
+		RFB_EXT_CLIPBOARD_ACTION_REQUEST |
+		RFB_EXT_CLIPBOARD_ACTION_PEEK |
+		RFB_EXT_CLIPBOARD_ACTION_NOTIFY |
+		RFB_EXT_CLIPBOARD_ACTION_PROVIDE,
 };
 
 struct rfb_security_types_msg {
@@ -191,6 +211,17 @@ struct rfb_client_pointer_event_msg {
 	uint8_t button_mask;
 	uint16_t x;
 	uint16_t y;
+} RFB_PACKED;
+
+struct rfb_ext_clipboard_msg {
+	uint8_t type;
+	uint8_t padding[3];
+	uint32_t length;
+	uint32_t flags;
+	union {
+		uint32_t max_unsolicited_sizes[0];
+		unsigned char zlib_stream[0];
+	};
 } RFB_PACKED;
 
 struct rfb_cut_text_msg {


### PR DESCRIPTION
This patch implements the extended clipboard pseudo-encoding, specifically only the text format. The appeal of this protocol is that it specifies that the text must be UTF-8 rather than Latin-1. In addition, the text is encoded by zlib which can reduce the length of the freeze that would occur when pushing a large clipboard update over a low-bandwidth link so long as the text is compressible.

The library user/wayvnc doesn't need to do anything to enable the protocol. The protocol is request-based, but I integrated it with the existing interface by simply caching the response in a buffer in nvnc_send_cut_text which can be sent when the client sends a request. Alternatively, the API could be extended in some way and wayvnc's data control code would need to adapt to it.

The protocol states that text must be transmitted in CRLF, so I convert the client's text to LF before running the nvnc_cut_text_fn. The normal ServerCutText/ClientCutText states that line endings must be LF, so it's not like preserving original line endings was possible with strict clients in the past anyway. neatvnc didn't convert server text to Latin-1 before sending it to the client, so I don't convert text to CRLF before sending to the client here.

Tested with TigerVNC's client (vncviewer).
I have read and understood CONTRIBUTING.md.