### PR TITLE
enc: tight: Fix the size of the tile

### DIFF
--- a/src/enc/tight.c
+++ b/src/enc/tight.c
@@ -233,8 +233,8 @@ static int tight_apply_damage(struct tight_encoder* self,
 			struct pixman_box16 box = {
 				.x1 = x * TSL,
 				.y1 = y * TSL,
-				.x2 = ((x + 1) * TSL) - 1,
-				.y2 = ((y + 1) * TSL) - 1,
+				.x2 = (x + 1) * TSL,
+				.y2 = (y + 1) * TSL,
 			};
 
 			pixman_region_overlap_t overlap


### PR DESCRIPTION
If refinery is disabled, pixels at the tile its boundaries are not considered by the tight encoder. This can trigger the assert(self->n_rects > 0); when only pixels at the boundary are damaged, or can cause those lines not to be updated. Remove the -1 from y2, x2 to fix the size of the tile.

To trigger the assert, refinery must be either disabled in code or  ENCODER_IMPL_FLAG_IGNORES_DAMAGE must be set. https://github.com/jhofstee/qneatvnc/tree/trigger-tight-assert will trigger the assert and behaves as expected with this patch.

I have read and understood CONTRIBUTING.md