### PR TITLE
Send queued message when switching to continuous updates

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1398,6 +1398,9 @@ static int on_client_enable_continuous_updates(struct nvnc_client* client)
 		client->continuous_updates.y = ntohs(msg->y);
 		client->continuous_updates.width = ntohs(msg->width);
 		client->continuous_updates.height = ntohs(msg->height);
+
+		/* If there are any pending messages left, make sure they are processed */
+		process_fb_update_requests(client);
 	} else {
 		client->continuous_updates.x = 0;
 		client->continuous_updates.y = 0;


### PR DESCRIPTION
Since n_pending_request is decremented after client_send_led_state is done, it should be incremented when the LED status is queued. Especially when continues updates are used this could lead to a single FramebufferUpdateRequest tiggering only a LED status message and not the framebuffer update itself and hence noVNC e.g. never showed the initial display.

I have read and understood CONTRIBUTING.md.
