### PR TITLE
stream: Unref payload after failing to create req

### DIFF
--- a/src/stream/gnutls.c
+++ b/src/stream/gnutls.c
@@ -172,11 +172,11 @@ static int stream_gnutls_send(struct stream* self, struct rcbuf* payload,
 		stream_req_fn on_done, void* userdata)
 {
 	if (self->state == STREAM_STATE_CLOSED)
-		return -1;
+		goto failure;
 
 	struct stream_req* req = calloc(1, sizeof(*req));
 	if (!req)
-		return -1;
+		goto failure;
 
 	req->payload = payload;
 	req->on_done = on_done;
@@ -185,6 +185,10 @@ static int stream_gnutls_send(struct stream* self, struct rcbuf* payload,
 	TAILQ_INSERT_TAIL(&self->send_queue, req, link);
 
 	return stream_gnutls__flush(self);
+
+failure:
+	rcbuf_unref(payload);
+	return -1;
 }
 
 static ssize_t stream_gnutls_read(struct stream* base, void* dst, size_t size)

--- a/src/stream/tcp.c
+++ b/src/stream/tcp.c
@@ -218,11 +218,11 @@ int stream_tcp_send(struct stream* self, struct rcbuf* payload,
 		stream_req_fn on_done, void* userdata)
 {
 	if (self->state == STREAM_STATE_CLOSED)
-		return -1;
+		goto failure;
 
 	struct stream_req* req = calloc(1, sizeof(*req));
 	if (!req)
-		return -1;
+		goto failure;
 
 	req->payload = payload;
 	req->on_done = on_done;
@@ -231,21 +231,29 @@ int stream_tcp_send(struct stream* self, struct rcbuf* payload,
 	TAILQ_INSERT_TAIL(&self->send_queue, req, link);
 
 	return stream_tcp__flush(self);
+
+failure:
+	rcbuf_unref(payload);
+	return -1;
 }
 
 int stream_tcp_send_first(struct stream* self, struct rcbuf* payload)
 {
 	if (self->state == STREAM_STATE_CLOSED)
-		return -1;
+		goto failure;
 
 	struct stream_req* req = calloc(1, sizeof(*req));
 	if (!req)
-		return -1;
+		goto failure;
 
 	req->payload = payload;
 	TAILQ_INSERT_HEAD(&self->send_queue, req, link);
 
 	return stream_tcp__flush(self);
+
+failure:
+	rcbuf_unref(payload);
+	return -1;
 }
 
 void stream_tcp_exec_and_send(struct stream* self,


### PR DESCRIPTION
The stream req's payload will be unreffed upon the req being removed from the send queue and freed. But if a stream req cannot be created in stream_send in the first place then the payload should be unreffed before returning -1.

I have read and understood CONTRIBUTING.md.