### PR TITLE
server: Notify on all keyboard events with keysym

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -178,6 +178,7 @@ struct nvnc {
 	void* userdata;
 	nvnc_key_fn key_fn;
 	nvnc_key_fn key_code_fn;
+	nvnc_key_ext_fn key_ext_fn;
 	nvnc_pointer_fn pointer_fn;
 	nvnc_fb_req_fn fb_req_fn;
 	nvnc_client_fn new_client_fn;

--- a/include/neatvnc.h
+++ b/include/neatvnc.h
@@ -115,6 +115,11 @@ enum nvnc_auth_flags {
 	NVNC_AUTH_REQUIRE_ENCRYPTION = 1 << 1,
 };
 
+enum nvnc_keyboard_event_type {
+	NVNC_KEYBOARD_EVENT_TYPE_REGULAR = 0,
+	NVNC_KEYBOARD_EVENT_TYPE_QEMU = 1,
+};
+
 struct nvnc_log_data {
 	enum nvnc_log_level level;
 	const char* file;
@@ -122,6 +127,11 @@ struct nvnc_log_data {
 };
 
 typedef void (*nvnc_key_fn)(struct nvnc_client*, uint32_t key,
+                            bool is_pressed);
+typedef void (*nvnc_key_ext_fn)(struct nvnc_client*,
+                            enum nvnc_keyboard_event_type event_type,
+                            uint32_t key,
+                            uint32_t keysym,
                             bool is_pressed);
 typedef void (*nvnc_pointer_fn)(struct nvnc_client*, uint16_t x, uint16_t y,
                                 enum nvnc_button_mask);
@@ -192,6 +202,7 @@ void nvnc_set_name(struct nvnc* self, const char* name);
 
 void nvnc_set_key_fn(struct nvnc* self, nvnc_key_fn);
 void nvnc_set_key_code_fn(struct nvnc* self, nvnc_key_fn);
+void nvnc_set_key_ext_fn(struct nvnc* self, nvnc_key_ext_fn);
 void nvnc_set_pointer_fn(struct nvnc* self, nvnc_pointer_fn);
 void nvnc_set_fb_req_fn(struct nvnc* self, nvnc_fb_req_fn);
 void nvnc_set_new_client_fn(struct nvnc* self, nvnc_client_fn);

--- a/src/server.c
+++ b/src/server.c
@@ -1028,6 +1028,10 @@ static int on_client_key_event(struct nvnc_client* client)
 	if (fn)
 		fn(client, keysym, !!down_flag);
 
+	nvnc_key_ext_fn ext_fn = server->key_ext_fn;
+	if (ext_fn)
+		ext_fn(client, NVNC_KEYBOARD_EVENT_TYPE_REGULAR, 0, keysym, !!down_flag);
+
 	return sizeof(*msg);
 }
 
@@ -1044,6 +1048,7 @@ static int on_client_qemu_key_event(struct nvnc_client* client)
 
 	int down_flag = msg->down_flag;
 	uint32_t xt_keycode = ntohl(msg->keycode);
+	uint32_t keysym = ntohl(msg->keysym);
 
 	uint32_t evdev_keycode = code_map_qnum_to_linux[xt_keycode];
 	if (!evdev_keycode)
@@ -1052,6 +1057,10 @@ static int on_client_qemu_key_event(struct nvnc_client* client)
 	nvnc_key_fn fn = server->key_code_fn;
 	if (fn)
 		fn(client, evdev_keycode, !!down_flag);
+
+	nvnc_key_ext_fn ext_fn = server->key_ext_fn;
+	if (ext_fn)
+		ext_fn(client, NVNC_KEYBOARD_EVENT_TYPE_QEMU, evdev_keycode, keysym, !!down_flag);
 
 	return sizeof(*msg);
 }
@@ -2686,6 +2695,12 @@ EXPORT
 void nvnc_set_key_code_fn(struct nvnc* self, nvnc_key_fn fn)
 {
 	self->key_code_fn = fn;
+}
+
+EXPORT
+void nvnc_set_key_ext_fn(struct nvnc* self, nvnc_key_ext_fn fn)
+{
+    self->key_ext_fn = fn;
 }
 
 EXPORT


### PR DESCRIPTION
Right now users of neatvnc only receive either a 

* key event: containing a keysym (regular Keyboard Event)
* key_code event: not containing a keysym, but a linux key code (coming QEMU-Event)

on keyboard interactions.

Unfortunately the QEMU-key-code event lacks the keysym, which is present in the transport protocol. Without it, it's tricky to differentiate between different keyboard layouts. (E.g. `"` and `Ä` are the same Key in German and English Layout) and the server has to reconstruct it.

This PR adds another callback, which contains the keycode and keysym at the same time and is fired on both events.

I know this is probably not the best way, but extending the other callbacks would be API-Breaking.


I have read and understood CONTRIBUTING.md.
