### PR TITLE
OSX Build Fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,26 @@ if gnutls.found()
 	config.set('ENABLE_TLS', true)
 endif
 
+have_random = false
+
+if cc.has_function(
+	'getrandom',
+	prefix: '#include <stddef.h>\n#include <sys/random.h>',
+	args: [ '-D_GNU_SOURCE' ]
+)
+	config.set('HAVE_GETRANDOM', true)
+	have_random = true
+endif
+
+if cc.has_function(
+	'arc4random_buf',
+	prefix: '#include <stdlib.h>'
+)
+	config.set('HAVE_ARC4RANDOM', true)
+	have_random = true
+endif
+
+
 if nettle.found() and hogweed.found() and gmp.found()
 	dependencies += [ nettle, hogweed, gmp ]
 	enable_websocket = true
@@ -150,6 +170,9 @@ if nettle.found() and hogweed.found() and gmp.found()
 		'src/auth/apple-dh.c',
 		'src/auth/rsa-aes.c',
 	]
+	if not(have_random)
+		error('No random generator available')
+	endif
 endif
 
 if host_system == 'linux' and get_option('systemtap') and cc.has_header('sys/sdt.h')

--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,15 @@ if git.found()
 endif
 add_project_arguments('-DPROJECT_VERSION=@0@'.format(version), language: 'c')
 
-libdrm_inc = dependency('libdrm').partial_dependency(compile_args: true)
+libdrm_inc_path = get_option('drm_include_path')
+if libdrm_inc_path != ''
+	libdrm_inc = declare_dependency(
+		include_directories: include_directories(libdrm_inc_path)
+	)
+else
+	libdrm_inc = dependency('libdrm').partial_dependency(compile_args: true)
+endif
+
 
 add_project_arguments(c_args, language: 'c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('systemtap', type: 'boolean', value: false, description: 'Enable tracing 
 option('gbm', type: 'feature', value: 'auto', description: 'Enable GBM integration')
 option('h264', type: 'feature', value: 'auto', description: 'Enable open h264 encoding')
 option('experimental', type: 'boolean', value: false, description: 'Enable experimental features')
+option('drm_include_path', type: 'string', value: '', description: 'Use specified libdrm include directory')

--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -15,13 +15,24 @@
  */
 
 #include "crypto.h"
+#include "config.h"
 
 #include <stdint.h>
 
-// TODO: This is linux specific
+#if defined(HAVE_GETRANDOM)
 #include <sys/random.h>
+#elif defined(HAVE_ARC4RANDOM)
+#include <stdlib.h>
+#endif
+
 
 void crypto_random(uint8_t* dst, size_t len)
 {
+#if defined(HAVE_GETRANDOM)
 	getrandom(dst, len, 0);
+#elif defined(HAVE_ARC4RANDOM)
+	arc4random_buf(dst, len);
+#else
+#error No random generator available
+#endif
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -25,7 +25,11 @@
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
+#ifdef __STDC_NO_THREADS__
+#define thread_local _Thread_local
+#else
 #include <threads.h>
+#endif
 
 #ifdef HAVE_LIBAVUTIL
 #include <libavutil/avutil.h>


### PR DESCRIPTION
Right now neatvnc doesn't build out of the box in OSX.

* header files of libdrm are needed, but there is no way to build libdrm in OSX.
* OSX doesn't support threads.h (but _Thread_local)
* getrandom is linux only

Regarding arc4random: In the past this call seemed to be a [security issue](https://security.stackexchange.com/questions/85601/is-arc4random-secure-enough), however at least [FreeBSD and OpenBSD](https://man.freebsd.org/cgi/man.cgi?query=arc4random) changed their implementation, OSX changed since version 10.12 (according to man page)

I have read and understood CONTRIBUTING.md.