### PR TITLE
server: Fix off by one error in crlf_to_lf

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1191,7 +1191,7 @@ static char* crlf_to_lf(const char* src, size_t len)
 			continue;
 		}
 
-		if ((in_len == 0) || (*(in + 1) != '\n'))
+		if ((in_len == 1) || (*(in + 1) != '\n'))
 			*out++ = '\n';
 
 		in++;


### PR DESCRIPTION
If the last character is a carriage return, we would have read one byte out of bounds. 'in_len' cannot be 0 at this point. When 'in' is pointing to the last character, 'in_len' is 1.

I have read and understood CONTRIBUTING.md.
