### PR TITLE
server: Return success on resize vs forwarded

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1951,7 +1951,7 @@ static enum rfb_resize_status check_desktop_layout(struct nvnc_client* client,
 		return RFB_RESIZE_STATUS_PROHIBITED;
 	}
 
-	return RFB_RESIZE_STATUS_REQUEST_FORWARDED;
+	return RFB_RESIZE_STATUS_SUCCESS;
 }
 
 static const char* resize_status_string(enum rfb_resize_status status)


### PR DESCRIPTION
For clients (tigervnc) that don't support forwarded/async (4)resizing responses resizing does not work properly.  Just returning success (0) should be alright until this more clients support it.   If Wayland fails to resize the result will be from the server to the client to resize back.