### PR TITLE
crypto: fix base16 decode buffer length

### DIFF
--- a/src/crypto/nettle/key.c
+++ b/src/crypto/nettle/key.c
@@ -91,7 +91,7 @@ static void initialise_p(mpz_t p)
 		"15728E5A8AACAA68FFFFFFFFFFFFFFFF";
 
 	char buf[256];
-	size_t len = 0;
+	size_t len = sizeof(buf);
 	struct base16_decode_ctx ctx;
 	nettle_base16_decode_init(&ctx);
 	nettle_base16_decode_update(&ctx, &len, (uint8_t*)buf, sizeof(s) - 1, s);
@@ -174,4 +174,3 @@ struct crypto_key* crypto_derive_shared_secret(
 
 	return shared;
 }
-


### PR DESCRIPTION
## Summary

Fix Apple-DH key initialization with Nettle 4.

`nettle_base16_decode_update()` requires `dst_length` to be the size of `dst`. `initialise_p()` was passing `0`, which causes decoding to fail with Nettle 4.

Initialize `len` to `sizeof(buf)` before decoding the Diffie-Hellman modulus.

Ref: https://git.lysator.liu.se/nettle/nettle/-/blob/master/base16.h?ref_type=heads#L91

## Backtrace

This was reproduced through wayvnc when connecting with a client that selects
Apple-DH authentication:

```text
...
#3  __assert_fail (assertion=0x7ffff7f9cf7f "len == sizeof(buf)",
    file=0x7ffff7f9cf50 "../subprojects/neatvnc/src/crypto/nettle/key.c",
    line=<optimized out>, function=<optimized out>) at assert.c:37
#4  0x00007ffff7f8f534 in initialise_p (p=0x5555555e0538)
    at ../subprojects/neatvnc/src/crypto/nettle/key.c:99
#5  0x00007ffff7f8f626 in crypto_keygen ()
    at ../subprojects/neatvnc/src/crypto/nettle/key.c:120
#6  0x00007ffff7f90a92 in apple_dh_send_public_key (client=0x5555555f33e0)
    at ../subprojects/neatvnc/src/auth/apple-dh.c:27
...
```

## Testing

```text
meson setup build -Dtests=true
ninja -C build
meson test -C build
```

Result:

```text
1/3 neatvnc:pixels        OK
2/3 neatvnc:base64        OK
3/3 neatvnc:rfb-handshake OK

Ok: 3
Fail: 0
```

Also verified manually by rebuilding wayvnc against this patched neatvnc and
connecting with the same Apple-DH client that previously triggered the abort.

I have read and understood CONTRIBUTING.md.

## Use of AI
I used GPT-5.5 via opencode to help diagnose and prepare the pull request.