### PR TITLE
server: Send the screen layout in an update of its own

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -610,6 +610,51 @@ static struct nvnc_desktop_layout* build_desktop_layout(
 	return layout;
 }
 
+/* Send a FramebufferUpdate that carries nothing but the screen layout.
+ *
+ * An update containing an ExtendedDesktopSize rect must not contain any
+ * changes to the framebuffer data, neither before nor after the rect, so the
+ * layout always travels in a message of its own.
+ */
+static int send_desktop_resize_update(struct nvnc_client* client,
+		const struct nvnc_desktop_layout* layout)
+{
+	struct rfb_server_fb_update_msg head = {
+		.type = RFB_SERVER_TO_CLIENT_FRAMEBUFFER_UPDATE,
+		.n_rects = htons(1),
+	};
+
+	if (stream_write(client->net_stream, &head, sizeof(head)) < 0)
+		return -1;
+
+	return send_desktop_resize_rect(client, layout);
+}
+
+/* Tell the client the current screen layout in reply to a non-incremental
+ * FramebufferUpdateRequest.
+ *
+ * The server must answer such a request with an ExtendedDesktopSize rect, as
+ * that is the only way a client learns that SetDesktopSize is supported.
+ * on_client_fb_update_request() sets this up by dropping the client's known
+ * layout, which is what we key on here.
+ */
+static void send_desktop_size_announcement(struct nvnc_client* client)
+{
+	struct nvnc* server = client->server;
+	uint16_t width, height;
+
+	calculate_desktop_extents(server, &width, &height);
+
+	struct nvnc_desktop_layout* layout =
+		build_desktop_layout(server, width, height);
+	if (!layout)
+		return;
+
+	send_desktop_resize_update(client, layout);
+
+	free(layout);
+}
+
 static int send_server_init_message(struct nvnc_client* client)
 {
 	struct nvnc* server = client->server;
@@ -1151,6 +1196,20 @@ static void process_fb_update_requests(struct nvnc_client* client)
 	if (!client->continuous_updates_enabled &&
 	    client->n_pending_requests == 0)
 		return;
+
+	/* A non-incremental request drops the known layout, and must be
+	 * answered with the layout before anything else. The pseudo-rect
+	 * updates below each consume the request on their own, so without this
+	 * the reply can be a cursor or ext-support frame with no layout in it.
+	 * Clients that latch resize support at their first update -- TurboVNC
+	 * does -- then conclude that resizing is unsupported.
+	 */
+	if (!client->known_layout && client_supports_resizing(client)) {
+		send_desktop_size_announcement(client);
+
+		if (decrement_pending_requests(client) <= 0)
+			return;
+	}
 
 	if (!client->is_ext_notified) {
 		client->is_ext_notified = true;
@@ -2895,15 +2954,18 @@ static void finish_fb_update(struct nvnc_client* client,
 		!client->known_layout ||
 		!nvnc_desktop_layout_eq(client->known_layout,
 				frame->metadata->desktop_layout);
-	if (is_resized) {
-		frame->n_rects += 1;
-
-		if (!client_supports_resizing(client)) {
-			nvnc_log(NVNC_LOG_ERROR, "Display has been resized but client does not support resizing.  Closing.");
-			client_close(client);
-			return;
-		}
+	if (is_resized && !client_supports_resizing(client)) {
+		nvnc_log(NVNC_LOG_ERROR, "Display has been resized but client does not support resizing.  Closing.");
+		client_close(client);
+		return;
 	}
+
+	/* The layout goes out in an update of its own, ahead of the frame, so
+	 * that the update carrying it contains no framebuffer data.
+	 */
+	if (is_resized && send_desktop_resize_update(client,
+				frame->metadata->desktop_layout) < 0)
+		goto complete;
 
 	struct rfb_server_fb_update_msg update_msg = {
 		.type = RFB_SERVER_TO_CLIENT_FRAMEBUFFER_UPDATE,
@@ -2911,10 +2973,6 @@ static void finish_fb_update(struct nvnc_client* client,
 	};
 	if (stream_write(client->net_stream, &update_msg,
 			sizeof(update_msg)) < 0)
-		goto complete;
-
-	if (is_resized && send_desktop_resize_rect(client,
-				frame->metadata->desktop_layout) < 0)
 		goto complete;
 
 	if (send_pts_rect(client, frame->pts) < 0)

--- a/test/rfb-test-server.c
+++ b/test/rfb-test-server.c
@@ -54,6 +54,36 @@ static void on_sigterm(struct aml_signal* sig)
 	aml_exit(aml_get_default());
 }
 
+#define FB_WIDTH 64
+#define FB_HEIGHT 64
+#define RESIZED_FB_WIDTH 128
+#define RESIZED_FB_HEIGHT 96
+
+static struct nvnc_display* test_display = NULL;
+static struct nvnc_frame* test_frame = NULL;
+
+static void feed_frame(uint16_t width, uint16_t height)
+{
+	struct nvnc_frame* fb = nvnc_frame_new(width, height,
+			DRM_FORMAT_RGBX8888, width);
+	assert(fb);
+
+	nvnc_display_feed_frame(test_display, fb);
+
+	if (test_frame)
+		nvnc_frame_unref(test_frame);
+	test_frame = fb;
+}
+
+/* Resize the desktop on demand, so that tests can exercise a server-initiated
+ * screen layout change.
+ */
+static void on_sigusr1(struct aml_signal* sig)
+{
+	(void)sig;
+	feed_frame(RESIZED_FB_WIDTH, RESIZED_FB_HEIGHT);
+}
+
 static int hex_to_bytes(const char* hex, uint8_t* out, size_t out_len)
 {
 	size_t hex_len = strlen(hex);
@@ -173,14 +203,12 @@ int main(int argc, char* argv[])
 		assert(rc == 0);
 	}
 
-	struct nvnc_display* display = nvnc_display_new(0, 0);
-	assert(display);
-	nvnc_add_display(server, display);
+	test_display = nvnc_display_new(0, 0);
+	assert(test_display);
+	nvnc_add_display(server, test_display);
 	nvnc_set_name(server, "test");
 
-	struct nvnc_frame* fb = nvnc_frame_new(64, 64, DRM_FORMAT_RGBX8888, 64);
-	assert(fb);
-	nvnc_display_feed_frame(display, fb);
+	feed_frame(FB_WIDTH, FB_HEIGHT);
 
 	/* SIGTERM handler for clean shutdown */
 	struct aml_signal* sig = aml_signal_new(SIGTERM, on_sigterm,
@@ -189,14 +217,20 @@ int main(int argc, char* argv[])
 	aml_start(aml, sig);
 	aml_unref(sig);
 
+	struct aml_signal* resize_sig = aml_signal_new(SIGUSR1, on_sigusr1,
+			NULL, NULL);
+	assert(resize_sig);
+	aml_start(aml, resize_sig);
+	aml_unref(resize_sig);
+
 	printf("READY %d\n", port);
 	fflush(stdout);
 
 	aml_run(aml);
 
 	nvnc_del(server);
-	nvnc_display_unref(display);
-	nvnc_frame_unref(fb);
+	nvnc_display_unref(test_display);
+	nvnc_frame_unref(test_frame);
 	aml_unref(aml);
 
 	return 0;

--- a/test/test_rfb_handshake.py
+++ b/test/test_rfb_handshake.py
@@ -13,6 +13,10 @@ Verifies:
 - VeNCrypt: X509_PLAIN auth success with correct credentials
 - VeNCrypt: X509_PLAIN auth failure with wrong password
 - VeNCrypt: X509_PLAIN auth failure with wrong username
+- ExtendedDesktopSize: the layout answers a non-incremental update request
+- ExtendedDesktopSize: the layout update carries no framebuffer data
+- ExtendedDesktopSize: no layout rect for a client that did not request it
+- ExtendedDesktopSize: a server-side resize sends the layout on its own
 
 Usage: python3 test_rfb_handshake.py <path-to-rfb-test-server>
 """
@@ -69,6 +73,10 @@ class ServerProcess:
                 raise RuntimeError(
                     f'Server exited without printing READY\n'
                     f'stderr: {stderr}')
+
+    def resize(self):
+        """Make the server resize its desktop to RESIZED_FB_*."""
+        self.proc.send_signal(signal.SIGUSR1)
 
     def stop(self):
         self.proc.send_signal(signal.SIGTERM)
@@ -215,12 +223,100 @@ class RFBConnection:
         assert reason_len > 0, 'Expected non-empty reason string'
         return result, data[8:8 + reason_len].decode('utf-8', errors='replace')
 
+    # Post-authentication helpers
+
+    def send_client_init(self, shared=1):
+        self.sock.sendall(struct.pack('!B', shared))
+
+    def read_server_init(self):
+        """Read ServerInit, returning (width, height, name).
+
+        The pixel format is retained as bytes_per_pixel, which is needed to
+        consume Raw rect payloads.
+        """
+        width, height = struct.unpack('!HH', self.recv_exact(4))
+        pixel_format = self.recv_exact(16)
+        self.bytes_per_pixel = pixel_format[0] // 8
+        name_len = struct.unpack('!I', self.recv_exact(4))[0]
+        name = self.recv_exact(name_len).decode('utf-8', errors='replace')
+        return width, height, name
+
+    def send_set_encodings(self, encodings):
+        self.sock.sendall(struct.pack('!BBH', 2, 0, len(encodings)))
+        for encoding in encodings:
+            self.sock.sendall(struct.pack('!i', encoding))
+
+    def send_fb_update_request(self, incremental, x, y, width, height):
+        self.sock.sendall(struct.pack('!BBHHHH', 3, incremental, x, y,
+                                      width, height))
+
+    def read_framebuffer_update(self):
+        """Read one FramebufferUpdate, returning a list of parsed rects.
+
+        Raw is the only pixel encoding handled, since that is all these tests
+        ask for. Any other encoding would need its payload consumed by
+        encoding, so hitting one here is a test bug rather than something to
+        skip past.
+        """
+        msg_type = struct.unpack('!B', self.recv_exact(1))[0]
+        assert msg_type == 0, f'Expected FramebufferUpdate, got message {msg_type}'
+        self.recv_exact(1)  # padding
+        n_rects = struct.unpack('!H', self.recv_exact(2))[0]
+
+        rects = []
+        for _ in range(n_rects):
+            x, y, width, height, encoding = struct.unpack('!HHHHi',
+                                                          self.recv_exact(12))
+            rect = {
+                'encoding': encoding,
+                'width': width,
+                'height': height,
+            }
+            if encoding == ENCODING_EXTENDED_DESKTOP_SIZE:
+                # x and y carry the reason and status for this pseudo-encoding.
+                rect['reason'] = x
+                rect['status'] = y
+                n_screens = struct.unpack('!B', self.recv_exact(1))[0]
+                self.recv_exact(3)  # padding
+                rect['screens'] = [
+                    dict(zip(('id', 'x', 'y', 'width', 'height', 'flags'),
+                             struct.unpack('!IHHHHI', self.recv_exact(16))))
+                    for _ in range(n_screens)
+                ]
+            elif encoding == ENCODING_RAW:
+                self.recv_exact(width * height * self.bytes_per_pixel)
+            elif encoding != ENCODING_DESKTOP_SIZE:
+                raise AssertionError(f'Unexpected encoding {encoding} in update')
+            rects.append(rect)
+        return rects
+
+    def handshake_to_encodings(self):
+        """Take a no-auth RFB 3.8 connection as far as ServerInit."""
+        assert SECURITY_TYPE_NONE in self.read_security_type_list()
+        self.choose_security_type(SECURITY_TYPE_NONE)
+        assert self.read_security_result() == 0
+        self.send_client_init()
+        return self.read_server_init()
+
 
 # ---------------------------------------------------------------------------
 # Test classes
 # ---------------------------------------------------------------------------
 
 PASSWORD = 'testpass'
+
+SECURITY_TYPE_NONE = 1
+ENCODING_RAW = 0
+ENCODING_DESKTOP_SIZE = -223
+ENCODING_QEMU_EXT_KEY_EVENT = -258
+ENCODING_EXTENDED_DESKTOP_SIZE = -308
+
+# rfb-test-server feeds a single 64x64 frame from one display at 0,0, and
+# resizes to 128x96 on SIGUSR1.
+TEST_FB_WIDTH = 64
+TEST_FB_HEIGHT = 64
+RESIZED_FB_WIDTH = 128
+RESIZED_FB_HEIGHT = 96
 
 
 class TestDESAuth(unittest.TestCase):
@@ -426,6 +522,128 @@ class TestAuthBypass(unittest.TestCase):
             data = c.recv_all()
             self.assertEqual(len(data), 4, f'Expected 4 bytes, got {len(data)}')
             self.assertEqual(struct.unpack('!I', data)[0], 1)
+
+
+class TestExtendedDesktopSize(unittest.TestCase):
+    """A non-incremental update request must be answered with the layout.
+
+    The spec requires the server to send an ExtendedDesktopSize rect in reply
+    to a FramebufferUpdateRequest with incremental set to zero, since that is
+    the only way a client learns that SetDesktopSize is supported. Clients that
+    latch this at their first framebuffer update -- TurboVNC does so
+    permanently -- otherwise conclude that resizing is unsupported.
+    """
+
+    server = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ServerProcess('none')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_layout_answers_a_non_incremental_request(self):
+        """The layout must come before the other pseudo-rect updates.
+
+        QEMUExtendedKeyEvent makes the server want to send an ext-support
+        frame, which used to consume the request and answer it with an update
+        that had no ExtendedDesktopSize rect in it.
+        """
+        with RFBConnection(self.server.port, 'RFB 003.008\n') as c:
+            width, height, _ = c.handshake_to_encodings()
+            self.assertEqual((width, height), (TEST_FB_WIDTH, TEST_FB_HEIGHT))
+
+            c.send_set_encodings([ENCODING_RAW,
+                                  ENCODING_EXTENDED_DESKTOP_SIZE,
+                                  ENCODING_QEMU_EXT_KEY_EVENT])
+            c.send_fb_update_request(0, 0, 0, width, height)
+
+            rects = c.read_framebuffer_update()
+
+            self.assertEqual(len(rects), 1,
+                             'the layout must arrive before anything else')
+            rect = rects[0]
+            self.assertEqual(rect['encoding'], ENCODING_EXTENDED_DESKTOP_SIZE)
+            self.assertEqual(rect['reason'], 0, 'should be server-initiated')
+            self.assertEqual(rect['status'], 0, 'should report success')
+            self.assertEqual((rect['width'], rect['height']),
+                             (TEST_FB_WIDTH, TEST_FB_HEIGHT))
+            self.assertEqual(len(rect['screens']), 1)
+            self.assertEqual(
+                (rect['screens'][0]['width'], rect['screens'][0]['height']),
+                (TEST_FB_WIDTH, TEST_FB_HEIGHT))
+
+    def test_layout_update_carries_no_framebuffer_data(self):
+        """An update holding the layout must contain nothing else."""
+        with RFBConnection(self.server.port, 'RFB 003.008\n') as c:
+            width, height, _ = c.handshake_to_encodings()
+
+            c.send_set_encodings([ENCODING_RAW, ENCODING_EXTENDED_DESKTOP_SIZE])
+            c.send_fb_update_request(0, 0, 0, width, height)
+
+            rects = c.read_framebuffer_update()
+
+            self.assertEqual([rect['encoding'] for rect in rects],
+                             [ENCODING_EXTENDED_DESKTOP_SIZE])
+
+    def test_no_layout_rect_without_the_encoding(self):
+        """A client that cannot parse the rect must not be sent one."""
+        with RFBConnection(self.server.port, 'RFB 003.008\n') as c:
+            width, height, _ = c.handshake_to_encodings()
+
+            c.send_set_encodings([ENCODING_RAW])
+            c.send_fb_update_request(0, 0, 0, width, height)
+
+            rects = c.read_framebuffer_update()
+
+            self.assertTrue(rects, 'expected framebuffer data')
+            for rect in rects:
+                self.assertEqual(rect['encoding'], ENCODING_RAW)
+
+
+class TestServerInitiatedResize(unittest.TestCase):
+    """A resize on the server sends the layout in an update of its own.
+
+    The spec forbids an update containing an ExtendedDesktopSize rect from
+    carrying any framebuffer data, neither before nor after the rect.
+    """
+
+    def test_resize_layout_arrives_without_framebuffer_data(self):
+        server = ServerProcess('none')
+        try:
+            with RFBConnection(server.port, 'RFB 003.008\n') as c:
+                width, height, _ = c.handshake_to_encodings()
+
+                c.send_set_encodings([ENCODING_RAW,
+                                      ENCODING_EXTENDED_DESKTOP_SIZE])
+
+                # Drain the layout that answers the non-incremental request.
+                c.send_fb_update_request(0, 0, 0, width, height)
+                self.assertEqual(c.read_framebuffer_update()[0]['width'],
+                                 TEST_FB_WIDTH)
+
+                server.resize()
+
+                rect = None
+                for _ in range(8):
+                    c.send_fb_update_request(1, 0, 0, width, height)
+                    rects = c.read_framebuffer_update()
+                    if rects[0]['encoding'] != ENCODING_EXTENDED_DESKTOP_SIZE:
+                        continue
+                    self.assertEqual(len(rects), 1,
+                                     'the resize must not carry pixel data')
+                    rect = rects[0]
+                    break
+
+                self.assertIsNotNone(rect, 'no layout rect after the resize')
+                self.assertEqual(rect['reason'], 0, 'should be server-initiated')
+                self.assertEqual(rect['status'], 0, 'should report success')
+                self.assertEqual((rect['width'], rect['height']),
+                                 (RESIZED_FB_WIDTH, RESIZED_FB_HEIGHT))
+        finally:
+            server.stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #180.

> The server must send an ExtendedDesktopSize rectangle in response to a FramebufferUpdateRequest with incremental set to zero, assuming the client has requested the ExtendedDesktopSize pseudo-encoding using the SetEncodings message.

neatvnc already tries to honour this. `on_client_fb_update_request()` drops `client->known_layout` on a non-incremental request, so that `finish_fb_update()` sees `is_resized` and emits the rect with the next frame.

`process_fb_update_requests()` never gets that far. Ahead of the frame it runs `send_ext_support_frame()`, `send_cursor_update()`, `send_desktop_name_update()` and `client_send_led_state()`, and each of those sends a single-rect `FramebufferUpdate` of its own and then returns on `decrement_pending_requests(client) <= 0`. So the client's first non-incremental request is answered by a QEMU/NTP/cursor pseudo-rect update with no `ExtendedDesktopSize` rect in it.

TurboVNC latches at that first `framebufferUpdateEnd()` (`CConn.java` → `params.desktopSize.setMode(DesktopSize.SERVER)`) and never re-checks, so the desktop stops following the window. TigerVNC is unaffected only because it assumes support optimistically and sends `SetDesktopSize` anyway, which neatvnc handles correctly.

This announces the layout from the top of `process_fb_update_requests()`, keyed on the dropped `known_layout`, so it goes out ahead of the side channels and the non-incremental request is answered with the layout. `send_desktop_resize_rect()` records the layout, so the frame that follows does not duplicate the rect.

### Also in that section of the spec

> An update containing an ExtendedDesktopSize rectangle must not contain any changes to the framebuffer data, neither before nor after the ExtendedDesktopSize rectangle.

`finish_fb_update()` packs the rect into the same update as the encoded frame, which is independent of #180. Both paths now go through `send_desktop_resize_update()`, which puts the rect in a `FramebufferUpdate` of its own. For the `DesktopSize` fallback this also satisfies that section's "should be the very last rectangle in an update" advice, since it becomes the only rectangle.

### Testing

`test/test_rfb_handshake.py` already has the harness for this — it drives `rfb-test-server` over raw RFB and `test/meson.build` registers it. `rfb-test-server` gains a `SIGUSR1` handler that resizes the desktop from 64x64 to 128x96, so the server-initiated path is reachable from the tests.

- **`test_layout_answers_a_non_incremental_request`** — advertises `ExtendedDesktopSize` *and* `QEMUExtendedKeyEvent`, then sends `FramebufferUpdateRequest` with `incremental` set to zero, and expects the first update back to be the layout rect alone (reason 0, status 0, 64x64, one screen). The QEMU encoding is what makes this bite: it gives `send_ext_support_frame()` something to send.
- **`test_layout_update_carries_no_framebuffer_data`** — the update holding the layout contains that rect and nothing else.
- **`test_no_layout_rect_without_the_encoding`** — a client advertising only `Raw` gets framebuffer data and no layout rect, so an unconditional announcement would not slip through.
- **`test_resize_layout_arrives_without_framebuffer_data`** — after a `SIGUSR1` resize, the layout arrives as a single-rect update reporting 128x96, separate from the pixel data.

Confirmed the tests pin the behaviour by reverting `src/server.c` to master and leaving the tests in place:

```
with the fix:     Ran 18 tests -- OK
without the fix:  FAIL: test_layout_answers_a_non_incremental_request
                        AssertionError: Unexpected encoding -258 in update
                  FAIL: test_layout_update_carries_no_framebuffer_data
                  FAIL: test_resize_layout_arrives_without_framebuffer_data
```

`-258` is `QEMUExtendedKeyEvent` — the ext-support frame answering the request instead of the layout.

`test_no_layout_rect_without_the_encoding` passes either way, as it should. The suite is behind `-Dtests=true`, so `meson setup build -Dtests=true && meson test -C build rfb-handshake` is what runs it.

### End-to-end

The original revision of this PR was backported onto the 1.0.1 Arch package and run against wayvnc 0.10.1 with TurboVNC Viewer 3.3.1: before, the viewer logged `Disabling automatic desktop resizing because the server doesn't support it` on every connect; after, that message was gone and the desktop resized to the viewer window (verified via `hyprctl monitors` reporting the window's size rather than the compositor's default). TigerVNC was unchanged.

That run predates this rework, so it has been repeated against the current branch — see the comment below for the before/after logs and `hyprctl monitors` output.

*(The branch is still named `announce-desktop-size-at-connect` from the first revision; renaming it would close the PR.)*
