### PR TITLE
tcp: Fix double free in stream_tcp_destroy()

### DIFF
--- a/src/stream/tcp.c
+++ b/src/stream/tcp.c
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <assert.h>
@@ -45,7 +46,19 @@ int stream_tcp_close(struct stream* self)
 	self->state = STREAM_STATE_CLOSED;
 	self->cork = true;
 
-	stream_ref(self);
+	/*
+	 * stream_tcp_destroy() calls us while self->ref is already 0, as
+	 * part of tearing self down. In that case we must not take a
+	 * temporary reference below: dropping it again via stream_destroy()
+	 * would hit zero and invoke self->impl->destroy() a second time,
+	 * freeing self and self->handler twice. Only do the ref dance when
+	 * we're being called on a still-live stream, to protect self across
+	 * the stream_req__finish() callbacks below, which may drop the
+	 * caller's own last reference.
+	 */
+	bool is_self_destructing = self->ref == 0;
+	if (!is_self_destructing)
+		stream_ref(self);
 
 	while (!TAILQ_EMPTY(&self->send_queue)) {
 		struct stream_req* req = TAILQ_FIRST(&self->send_queue);
@@ -58,7 +71,8 @@ int stream_tcp_close(struct stream* self)
 	self->fd = -1;
 
 	// unref
-	stream_destroy(self);
+	if (!is_self_destructing)
+		stream_destroy(self);
 
 	return 0;
 }


### PR DESCRIPTION
## What

`stream_tcp_close()` takes a temporary reference (`stream_ref()`) before
flushing the send queue, then drops it again via `stream_destroy()` at
the end, to keep `self` alive across the `stream_req__finish()`
callbacks it invokes.

That's correct when an external caller still holds a reference
(`self->ref >= 1`) — the normal `client_close()` path, which calls
`stream_close()` before `stream_destroy()`. But `stream_tcp_destroy()`
itself calls `stream_close()` with `self->ref` already at `0`, since it
only runs once the generic `stream_destroy()` wrapper has already
dropped `ref` to zero. In that case the ref-bump-then-drop hits zero
again and invokes `self->impl->destroy()` a second, recursive time,
freeing `self` and `self->handler` twice.

## Impact

`on_connection()` in `server.c` reaches this directly: when a client
connects before any display buffer has been fed to the server, it
calls `stream_destroy()` on the freshly created, never-closed stream
(the `buffer_failure` path). That crashes the whole process with a
double free / use-after-free, instead of just failing that one
connection. It reproduces reliably with wayvnc on a wlroots compositor
if a client connects in the window before the first frame has been
captured.

## Testing

- Added a minimal reproduction (server with a display added but no
  frame fed, then a bare TCP connect) — crashes every time on
  unpatched `master`, confirmed via gdb backtrace matching this code
  path (`aml_handler_unref` ← `stream_tcp_destroy` (tcp.c:70) ←
  `on_connection` (server.c:2525)). Passes cleanly after this fix.
- `meson test -C build` passes (base64, pixels, utf8, rfb-handshake —
  18 RFB handshake/auth tests including DES and VeNCrypt).
- Deployed the patched library in place of the packaged v1.0.1 on a
  real wayvnc + Hyprland (NVIDIA) setup that was previously crashing
  on essentially every VNC connection attempt; confirmed fixed under
  a real client connection.

I have read and understood CONTRIBUTING.md.
